### PR TITLE
feat: history item 기능

### DIFF
--- a/sample.json
+++ b/sample.json
@@ -1,0 +1,57 @@
+[
+  {
+    "faviconSrc": "https://ko.wikipedia.org/static/favicon/wikipedia.ico",
+    "siteTitle": "호그와트 - 위키백과, 우리 모두의 백과사전",
+    "url": "https://ko.wikipedia.org/wiki/%ED%98%B8%EA%B7%B8%EC%99%80%ED%8A%B8#:~:text=%ED%98%B8%EA%B7%B8%EC%99%80%ED%8A%B8%20%EB%A7%88%EB%B2%95%ED%95%99%EA%B5%90(%EC%98%81%EC%96%B4%3A%20Hogwarts%20School%20of%20Witchcraft%20and%20Wizardry)%EB%8A%94%20%EC%86%8C%EC%84%A4%20%E3%80%8A%ED%95%B4%EB%A6%AC%20%ED%8F%AC%ED%84%B0%E3%80%8B%20%EC%8B%9C%EB%A6%AC%EC%A6%88%EC%97%90%20%EB%93%B1%EC%9E%A5%ED%95%98%EB%8A%94%20%EA%B3%A0%EB%93%9C%EB%A6%AD%20%EA%B7%B8%EB%A6%AC%ED%95%80%EB%8F%84%EB%A5%B4%2C%20%EC%82%B4%EB%9D%BC%EC%9E%90%EB%A5%B4%20%EC%8A%AC%EB%A6%AC%EB%8D%B0%EB%A6%B0%2C",
+    "createdTime": "2025-01-23T10:41:43.635Z",
+    "keywords": [{ "keyword": "호그와트", "count": 39 }]
+  },
+  {
+    "faviconSrc": "https://namu.wiki/favicon.svg",
+    "siteTitle": "투슬리스 - 나무위키",
+    "url": "https://namu.wiki/w/%ED%88%AC%EC%8A%AC%EB%A6%AC%EC%8A%A4",
+    "createdTime": "2025-01-23T10:44:42.451Z",
+    "keywords": [
+      { "keyword": "드래곤", "count": 128 },
+      { "keyword": "퓨어리", "count": 2 },
+      { "keyword": "투슬리스", "count": 167 }
+    ]
+  },
+  {
+    "faviconSrc": "https://ko.wikipedia.org/static/favicon/wikipedia.ico",
+    "siteTitle": "사슴 - 위키백과, 우리 모두의 백과사전",
+    "url": "https://ko.wikipedia.org/wiki/%EC%82%AC%EC%8A%B4#:~:text=%EC%82%AC%EC%8A%B4%EC%9D%80%20%EC%82%AC%EC%8A%B4%EA%B3%BC(Cervidae)%20%EB%8F%99%EB%AC%BC%EC%9D%98%20%EC%B4%9D%EC%B9%AD%EC%9C%BC%EB%A1%9C%2C%20%ED%8F%AC%EC%9C%A0%EA%B0%95%20%EC%9A%B0%EC%A0%9C%EB%AA%A9%2F%EA%B2%BD%EC%9A%B0%EC%A0%9C%EB%AA%A9%EC%9D%98%20%ED%95%9C%20%EA%B3%BC%EB%A5%BC%20%EC%9D%B4%EB%A3%AC%EB%8B%A4",
+    "createdTime": "2025-01-23T10:47:21.387Z",
+    "keywords": [
+      { "keyword": "먹이", "count": 9 },
+      { "keyword": "발굽", "count": 1 },
+      { "keyword": "노루", "count": 16 },
+      { "keyword": "사슴", "count": 151 },
+      { "keyword": "뿔", "count": 15 }
+    ]
+  },
+  {
+    "faviconSrc": "https://developer.mozilla.org/favicon-48x48.bc390275e955dacb2e65.png",
+    "siteTitle": "async function - JavaScript | MDN",
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function",
+    "createdTime": "2025-01-23T10:51:24.727Z",
+    "keywords": [
+      { "keyword": "expressions", "count": 7 },
+      { "keyword": "promise", "count": 43 },
+      { "keyword": "await", "count": 50 },
+      { "keyword": "async", "count": 66 }
+    ]
+  },
+  {
+    "faviconSrc": "https://www.hogwartslegacy.com/images/favicon-32x32.png",
+    "siteTitle": "호그와트 레거시 - 홈",
+    "url": "https://www.hogwartslegacy.com/ko-kr#:~:text=%ED%98%B8%EA%B7%B8%EC%99%80%ED%8A%B8%20%EB%A0%88%EA%B1%B0%EC%8B%9C%EB%8A%94%20%ED%95%B4%EB%A6%AC%20%ED%8F%AC%ED%84%B0%20%EC%84%B8%EA%B3%84%EA%B4%80%EC%97%90%EC%84%9C%20%EC%A7%84%ED%96%89%EB%90%98%EB%8A%94%20%EB%AA%B0%EC%9E%85%ED%98%95%20%EC%98%A4%ED%94%88%EC%9B%94%EB%93%9C%20%EC%95%A1%EC%85%98%20RPG%EC%9E%85%EB%8B%88%EB%8B%A4",
+    "createdTime": "2025-01-23T10:53:51.501Z",
+    "keywords": [
+      { "keyword": "1800년대", "count": 1 },
+      { "keyword": "마법", "count": 14 },
+      { "keyword": "오픈월드", "count": 1 },
+      { "keyword": "호그와트", "count": 3 }
+    ]
+  }
+]

--- a/src/History/DragAndDrop.jsx
+++ b/src/History/DragAndDrop.jsx
@@ -1,14 +1,23 @@
 import { useRef, useState } from "react";
 
+import sample from "../../sample.json";
 import NewKeywordButton from "../shared/NewKeywordButton";
 import KeywordGroup from "./KeywordGroup";
 
 export default function DragAndDrop() {
   const dragPosition = useRef();
   const [list, setList] = useState([
-    { id: 0, name: "New Keyword Group", keywords: ["key", "key2"] },
+    {
+      id: 0,
+      name: "New Keyword Group",
+      keywords: ["keyword1", "keyword2"],
+      count: [0, 2],
+    },
   ]);
 
+  const sampleData = sample;
+  console.log(sampleData);
+  console.log(sample.keywords);
   const startDrag = (event, groupIndex, keyword) => {
     dragPosition.current = { groupIndex, keyword };
   };
@@ -24,10 +33,10 @@ export default function DragAndDrop() {
     );
     newList[groupIndex].keywords.push(keyword);
 
-    // 키워드의 카운트 -> 각각 정보를 map돎면서 순회
     dragPosition.current = null;
     setList(newList);
   };
+
   const newKeywordGroup = (groupName) => {
     const newGroupId = list.length + 1;
 

--- a/src/History/DragAndDrop.jsx
+++ b/src/History/DragAndDrop.jsx
@@ -1,6 +1,5 @@
 import { useRef, useState } from "react";
 
-import sample from "../../sample.json";
 import NewKeywordButton from "../shared/NewKeywordButton";
 import KeywordGroup from "./KeywordGroup";
 
@@ -10,14 +9,11 @@ export default function DragAndDrop() {
     {
       id: 0,
       name: "New Keyword Group",
-      keywords: ["keyword1", "keyword2"],
-      count: [0, 2],
+      keywords: ["exampleData", "keyword2", "deisp"],
+      count: [],
     },
   ]);
 
-  const sampleData = sample;
-  console.log(sampleData);
-  console.log(sample.keywords);
   const startDrag = (event, groupIndex, keyword) => {
     dragPosition.current = { groupIndex, keyword };
   };

--- a/src/History/DragAndDrop.jsx
+++ b/src/History/DragAndDrop.jsx
@@ -1,27 +1,21 @@
 import { useRef, useState } from "react";
 
+import NewKeywordButton from "../shared/NewKeywordButton";
 import KeywordGroup from "./KeywordGroup";
 
 export default function DragAndDrop() {
   const dragPosition = useRef();
   const [list, setList] = useState([
-    { id: 1, name: "Keyword 1", keywords: [] },
-    { id: 2, name: "Keyword 2", keywords: ["keyword1", "keyword2"] },
-    { id: 3, name: "Keyword 3", keywords: ["keyword3"] },
-    { id: 4, name: "Keyword 4", keywords: ["keyword4", "keyword5"] },
-    {
-      id: 5,
-      name: "Keyword 4",
-      keywords: ["keyword6", "keyword7", "keyword8"],
-    },
+    { id: 0, name: "New Keyword Group", keywords: ["key", "key2"] },
   ]);
 
-  const dragStart = (event, groupIndex, keyword) => {
+  const startDrag = (event, groupIndex, keyword) => {
     dragPosition.current = { groupIndex, keyword };
   };
 
   const drop = (event, groupIndex) => {
     event.preventDefault();
+
     const newList = [...list];
     const { groupIndex: dragGroupIndex, keyword } = dragPosition.current;
 
@@ -30,18 +24,35 @@ export default function DragAndDrop() {
     );
     newList[groupIndex].keywords.push(keyword);
 
+    // 키워드의 카운트 -> 각각 정보를 map돎면서 순회
     dragPosition.current = null;
     setList(newList);
+  };
+  const newKeywordGroup = (groupName) => {
+    const newGroupId = list.length + 1;
+
+    if (groupName.trim() === false) {
+      return null;
+    }
+
+    const newGroup = {
+      id: newGroupId,
+      name: groupName.trim(),
+      keywords: [],
+    };
+
+    setList((prevList) => [...prevList, newGroup]);
   };
 
   return (
     <>
+      <NewKeywordButton addGroup={newKeywordGroup} />
       {list.map((item, index) => (
         <KeywordGroup
           key={item.id}
-          keyword={item.name}
+          groupName={item.name}
           keywords={item.keywords}
-          onDragStart={(event, keyword) => dragStart(event, index, keyword)}
+          onDragStart={(event, keyword) => startDrag(event, index, keyword)}
           onDrop={(event) => drop(event, index)}
         />
       ))}

--- a/src/History/HistoryItem.jsx
+++ b/src/History/HistoryItem.jsx
@@ -1,11 +1,22 @@
 import PropTypes from "prop-types";
 
+import sample from "../../sample.json";
 import DeleteButton from "../shared/DeleteButton";
 import SearchKeyword from "./SearchKeyword";
 import SearchUrl from "./SearchUrl";
 import { TotalKeywordButton } from "./TotalKeywordButton";
 
 export default function HistoryItem({ keywords, onDragStart, onDrop }) {
+  const data = sample;
+  let siteUrl;
+  let siteName;
+  for (let i = 0; i < data.length; i++) {
+    siteUrl = data[i].siteTitle;
+  }
+  for (let i = 0; i < data.length; i++) {
+    siteName = data[i].url;
+  }
+
   return (
     <div
       className="text-left w-[100%] shadow-md rounded-[10px]"
@@ -34,10 +45,8 @@ export default function HistoryItem({ keywords, onDragStart, onDrop }) {
               <div>
                 <div className="flex justify-between items-center gap-[30px] text-center">
                   <SearchUrl
-                    title={
-                      "https://www.notion.so/Sticky-Searcher-177f13b58350802bbeeaedd8b1d09f68"
-                    }
-                    url={"www.notion.so"}
+                    title={siteUrl}
+                    url={siteName}
                     time={"time"}
                   />
                 </div>

--- a/src/History/HistoryItem.jsx
+++ b/src/History/HistoryItem.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import DeleteButton from "../shared/DeleteButton";
 import SearchKeyword from "./SearchKeyword";
 import SearchUrl from "./SearchUrl";
+import { TotalKeywordButton } from "./TotalKeywordButton";
 
 export default function HistoryItem({ keywords, onDragStart, onDrop }) {
   return (
@@ -12,7 +13,7 @@ export default function HistoryItem({ keywords, onDragStart, onDrop }) {
       onDragOver={(event) => event.preventDefault()}
     >
       <div className="flex justify-center items-center gap-[10px] bg-none rounded-[10px] border px-[10px] ">
-        <ul className="w-full grid grid-cols-1 items-center gap-y-[15px] py-[20px] rounded-lg">
+        <ul className="w-full grid grid-cols-1 items-center gap-y-[15px] py-[3rem] rounded-lg">
           {keywords.map((keywordItem, index) => (
             <li
               key={index}
@@ -31,18 +32,21 @@ export default function HistoryItem({ keywords, onDragStart, onDrop }) {
                 />
               </label>
               <div>
-                <div className="flex justify-between items-center gap-[30px]">
+                <div className="flex justify-between items-center gap-[30px] text-center">
                   <SearchUrl
-                    title={"사용자의 검색환경을 개선해보자 🔎"}
-                    url={"github.com"}
-                    time={"오후 19:50"}
+                    title={
+                      "https://www.notion.so/Sticky-Searcher-177f13b58350802bbeeaedd8b1d09f68"
+                    }
+                    url={"www.notion.so"}
+                    time={"time"}
                   />
                 </div>
                 <div className="flex justify-center items-center gap-[15px]">
                   <SearchKeyword
                     keywords={keywordItem}
-                    keywordsTotal={10}
+                    keywordsTotal={keywordItem.length}
                   />
+                  <TotalKeywordButton />
                   <DeleteButton />
                 </div>
               </div>

--- a/src/History/KeywordGroup.jsx
+++ b/src/History/KeywordGroup.jsx
@@ -4,17 +4,17 @@ import HistoryItem from "./HistoryItem";
 import NewKeyword from "./NewKeyword";
 
 export default function KeywordGroup({
-  keyword,
+  groupName,
   keywords,
   onDragStart,
   onDrop,
 }) {
   return (
-    <div>
-      <NewKeyword keyword={keyword} />
+    <div className="newGroup">
+      <NewKeyword keyword={groupName} />
       <div className="flex justify-center items-center">
         <HistoryItem
-          keyword={keyword}
+          groupName={groupName}
           keywords={keywords}
           onDragStart={onDragStart}
           onDrop={onDrop}
@@ -25,7 +25,7 @@ export default function KeywordGroup({
 }
 
 KeywordGroup.propTypes = {
-  keyword: PropTypes.string.isRequired,
+  groupName: PropTypes.string.isRequired,
   keywords: PropTypes.array.isRequired,
   onDragStart: PropTypes.func.isRequired,
   onDrop: PropTypes.func.isRequired,

--- a/src/History/SearchKeyword.jsx
+++ b/src/History/SearchKeyword.jsx
@@ -1,13 +1,5 @@
 import PropTypes from "prop-types";
 
-// function TotalKeywordButton({ keyword = "..." }) {
-//   return (
-//     <button className="w-[25%] truncate shadow p-[5px] rounded-[5px]">
-//       {keyword}
-//     </button>
-//   );
-// }
-
 export default function SearchKeyword({ keywords, keywordsTotal }) {
   return (
     <>
@@ -17,22 +9,6 @@ export default function SearchKeyword({ keywords, keywordsTotal }) {
           {keywordsTotal}
         </span>
       </p>
-      <p className="bg-[#333] text-[#fff] truncate border w-[100%] h-[40px] px-[3px] leading-[37px] text-sm text-center rounded-full">
-        {keywords}
-        <span className="inline text-[#333] text-xs bg-[#fff] px-[5px] py-[1px] ml-[5px] rounded-full">
-          {keywordsTotal}
-        </span>
-      </p>
-      <p className="bg-[#333] text-[#fff] truncate border w-[100%] h-[40px] px-[3px] leading-[37px] text-sm text-center rounded-full">
-        {keywords}
-        <span className="inline text-[#333] text-xs bg-[#fff] px-[5px] py-[1px] ml-[5px] rounded-full">
-          {keywordsTotal}
-        </span>
-      </p>
-      {/* <button className="w-[25%] truncate shadow p-[5px] rounded-[5px]">
-        {keyword}
-      </button> */}
-      {/* <TotalKeywordButton /> */}
     </>
   );
 }
@@ -42,7 +18,3 @@ SearchKeyword.propTypes = {
   keywordsTotal: PropTypes.number,
   keyword: PropTypes.string,
 };
-
-// TotalKeywordButton.propTypes = {
-//   keyword: PropTypes.func,
-// };

--- a/src/History/SearchKeyword.jsx
+++ b/src/History/SearchKeyword.jsx
@@ -1,12 +1,12 @@
 import PropTypes from "prop-types";
 
-function TotalKeywordButton({ keyword = "..." }) {
-  return (
-    <button className="w-[20%] truncate shadow px-[3px] rounded-[5px]">
-      {keyword}
-    </button>
-  );
-}
+// function TotalKeywordButton({ keyword = "..." }) {
+//   return (
+//     <button className="w-[25%] truncate shadow p-[5px] rounded-[5px]">
+//       {keyword}
+//     </button>
+//   );
+// }
 
 export default function SearchKeyword({ keywords, keywordsTotal }) {
   return (
@@ -17,16 +17,32 @@ export default function SearchKeyword({ keywords, keywordsTotal }) {
           {keywordsTotal}
         </span>
       </p>
-      <TotalKeywordButton />
+      <p className="bg-[#333] text-[#fff] truncate border w-[100%] h-[40px] px-[3px] leading-[37px] text-sm text-center rounded-full">
+        {keywords}
+        <span className="inline text-[#333] text-xs bg-[#fff] px-[5px] py-[1px] ml-[5px] rounded-full">
+          {keywordsTotal}
+        </span>
+      </p>
+      <p className="bg-[#333] text-[#fff] truncate border w-[100%] h-[40px] px-[3px] leading-[37px] text-sm text-center rounded-full">
+        {keywords}
+        <span className="inline text-[#333] text-xs bg-[#fff] px-[5px] py-[1px] ml-[5px] rounded-full">
+          {keywordsTotal}
+        </span>
+      </p>
+      {/* <button className="w-[25%] truncate shadow p-[5px] rounded-[5px]">
+        {keyword}
+      </button> */}
+      {/* <TotalKeywordButton /> */}
     </>
   );
 }
 
-TotalKeywordButton.propTypes = {
-  keyword: PropTypes.string,
-};
-
 SearchKeyword.propTypes = {
   keywords: PropTypes.string,
   keywordsTotal: PropTypes.number,
+  keyword: PropTypes.string,
 };
+
+// TotalKeywordButton.propTypes = {
+//   keyword: PropTypes.func,
+// };

--- a/src/History/SearchKeyword.jsx
+++ b/src/History/SearchKeyword.jsx
@@ -1,6 +1,11 @@
 import PropTypes from "prop-types";
 
+import sample from "../../sample.json";
+
 export default function SearchKeyword({ keywords, keywordsTotal }) {
+  const sampleData = sample;
+  console.log(sampleData[0]);
+
   return (
     <>
       <p className="bg-[#333] text-[#fff] truncate border w-[100%] h-[40px] px-[3px] leading-[37px] text-sm text-center rounded-full">

--- a/src/History/SearchSection.jsx
+++ b/src/History/SearchSection.jsx
@@ -2,27 +2,29 @@ import PropTypes from "prop-types";
 
 export default function SearchSection({ warningText, iconSrc }) {
   return (
-    <div className="flex justify-between my-[20px] pb-[20px] border-b">
-      <em className="block text-[#d71313] py-[5px]">{warningText}</em>
-      <label
-        htmlFor="text"
-        className="w-[50%] border flex justify-between items-center rounded-full "
-      >
-        <input
-          id="text"
-          type="text"
-          placeholder="텍스트를 입력해 주세요!"
-          className="w-full h-[100%] rounded-full font-normal text-sm text-[#333] px-[15px]"
-        />
-        <button className="w-[10%] h-[30px] flex justify-center items-center">
-          <img
-            src={iconSrc}
-            alt="input-search.png"
-            className="w-[20px]"
+    <>
+      <div className="flex justify-between my-[20px] pb-[20px] border-b">
+        <em className="block text-[#d71313] py-[5px]">{warningText}</em>
+        <label
+          htmlFor="text"
+          className="w-[50%] border flex justify-between items-center rounded-full "
+        >
+          <input
+            id="text"
+            type="text"
+            placeholder="텍스트를 입력해 주세요!"
+            className="w-full h-[100%] rounded-full font-normal text-sm text-[#333] px-[15px]"
           />
-        </button>
-      </label>
-    </div>
+          <button className="w-[10%] h-[30px] flex justify-center items-center">
+            <img
+              src={iconSrc}
+              alt="input-search.png"
+              className="w-[20px]"
+            />
+          </button>
+        </label>
+      </div>
+    </>
   );
 }
 

--- a/src/History/SearchSection.jsx
+++ b/src/History/SearchSection.jsx
@@ -12,7 +12,7 @@ export default function SearchSection({ warningText, iconSrc }) {
           <input
             id="text"
             type="text"
-            placeholder="텍스트를 입력해 주세요!"
+            placeholder="생성했던 키워드 그룹을 입력해 주세요!"
             className="w-full h-[100%] rounded-full font-normal text-sm text-[#333] px-[15px]"
           />
           <button className="w-[10%] h-[30px] flex justify-center items-center">

--- a/src/History/SearchUrl.jsx
+++ b/src/History/SearchUrl.jsx
@@ -1,6 +1,22 @@
 import PropTypes from "prop-types";
+import { useState } from "react";
 
-export default function SearchUrl({ title, url, time }) {
+export default function SearchUrl({ title, url }) {
+  const [time, setTimer] = useState("00:00:00");
+  const currentTimer = () => {
+    const date = new Date();
+    const hours = String(date.getHours()).padStart(2, "0");
+    const minutes = String(date.getMinutes()).padStart(2, "0");
+    const seconds = String(date.getSeconds()).padStart(2, "0");
+    setTimer(`${hours}:${minutes}:${seconds}`);
+  };
+
+  const startTimer = () => {
+    setInterval(currentTimer, 1000);
+  };
+
+  startTimer(time);
+
   return (
     <>
       <a
@@ -11,7 +27,7 @@ export default function SearchUrl({ title, url, time }) {
         <p className="w-[200px] truncate">{title}</p>
         <span className="text-[#aaa] truncate text-sm font-light">{url}</span>
       </a>
-      <span className="w-[100px] text-[#aaa] text-sm">{time}</span>
+      <span className="w-[120px] text-[#aaa] text-sm">{time}</span>
     </>
   );
 }

--- a/src/History/SearchUrl.jsx
+++ b/src/History/SearchUrl.jsx
@@ -1,33 +1,36 @@
 import PropTypes from "prop-types";
-import { useState } from "react";
 
-export default function SearchUrl({ title, url }) {
-  const [time, setTimer] = useState("00:00:00");
-  const currentTimer = () => {
-    const date = new Date();
-    const hours = String(date.getHours()).padStart(2, "0");
-    const minutes = String(date.getMinutes()).padStart(2, "0");
-    const seconds = String(date.getSeconds()).padStart(2, "0");
-    setTimer(`${hours}:${minutes}:${seconds}`);
+import sample from "../../sample.json";
+
+export default function SearchUrl() {
+  const options = {
+    month: "numeric",
+    day: "numeric",
+    hour: "numeric",
+    minute: "numeric",
   };
+  const currentDate = new Intl.DateTimeFormat("ko-KR", options).format(
+    new Date(new Date().toISOString())
+  );
 
-  const startTimer = () => {
-    setInterval(currentTimer, 1000);
-  };
+  const data = sample;
 
-  startTimer(time);
+  const siteUrl = data[4].url;
+  const siteTitle = data[4].siteTitle;
 
   return (
     <>
       <a
-        href={title}
+        href={siteUrl}
         className="flex items-center gap-[20px]"
         target="_blank"
       >
-        <p className="w-[200px] truncate">{title}</p>
-        <span className="text-[#aaa] truncate text-sm font-light">{url}</span>
+        <p className="w-[200px] truncate">{siteTitle}</p>
+        <span className="w-[150px] text-[#aaa] truncate text-sm font-light">
+          {siteUrl}
+        </span>
       </a>
-      <span className="w-[120px] text-[#aaa] text-sm">{time}</span>
+      <span className="w-[120px] text-[#aaa] text-sm">{currentDate}</span>
     </>
   );
 }

--- a/src/History/TotalKeywordButton.jsx
+++ b/src/History/TotalKeywordButton.jsx
@@ -1,0 +1,13 @@
+import PropTypes from "prop-types";
+
+export function TotalKeywordButton({ keyword = "..." }) {
+  return (
+    <button className="w-[25%] truncate shadow p-[5px] rounded-[5px]">
+      {keyword}
+    </button>
+  );
+}
+
+TotalKeywordButton.propTypes = {
+  keyword: PropTypes.func,
+};

--- a/src/shared/DeleteButton.jsx
+++ b/src/shared/DeleteButton.jsx
@@ -1,6 +1,6 @@
 export default function DeleteButton() {
   return (
-    <button className="bg-[#333] text-[#fff] border w-[40%] h-[45px] rounded-full m-[15px]">
+    <button className="bg-[#333] text-[#fff] border w-[40%] h-[45px] rounded-full m-[15px] px-[15px]">
       Delete
     </button>
   );

--- a/src/shared/NewKeywordButton.jsx
+++ b/src/shared/NewKeywordButton.jsx
@@ -1,7 +1,43 @@
-export default function NewKeywordButton() {
+import PropTypes from "prop-types";
+import { useState } from "react";
+
+export default function NewKeywordButton({ addGroup }) {
+  const [inputText, setInputText] = useState("");
+
+  function handleChange(event) {
+    setInputText(event.target.value);
+  }
+
+  function handleClick() {
+    addGroup(inputText);
+    setInputText("");
+  }
+
   return (
-    <button className="bg-[#333] text-[#fff] border w-[170px] h-[50px] rounded-[10px] my-[20px]">
-      New Keyword +
-    </button>
+    <>
+      <label
+        htmlFor="text"
+        className="w-[100%] flex justify-between items-center rounded-full"
+      >
+        <input
+          onChange={handleChange}
+          type="text"
+          placeholder="키워드그룹을 생성해 주세요!"
+          value={inputText}
+          className="inline border w-full h-[50px] rounded-full font-normal text-sm text-[#333] px-[15px]"
+        />
+      </label>
+      <button
+        className="bg-[#333] text-[#fff] border w-[170px] h-[50px] rounded-[5px] my-[20px]"
+        onClick={handleClick}
+      >
+        {" "}
+        New Keyword +
+      </button>
+    </>
   );
 }
+
+NewKeywordButton.propTypes = {
+  addGroup: PropTypes.string.isRequired,
+};

--- a/src/shared/NewKeywordButton.jsx
+++ b/src/shared/NewKeywordButton.jsx
@@ -31,7 +31,6 @@ export default function NewKeywordButton({ addGroup }) {
         className="bg-[#333] text-[#fff] border w-[170px] h-[50px] rounded-[5px] my-[20px]"
         onClick={handleClick}
       >
-        {" "}
         New Keyword +
       </button>
     </>
@@ -39,5 +38,5 @@ export default function NewKeywordButton({ addGroup }) {
 }
 
 NewKeywordButton.propTypes = {
-  addGroup: PropTypes.string.isRequired,
+  addGroup: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
### 구현사진
https://github.com/user-attachments/assets/7c34c93a-bd6c-490f-8fa9-ef9e2ec26863

### 작업 내용
- 실질적인 url을 가져오고 클릭 시 해당 url로 이동합니다.
- New Keyword + 버튼을 클릭 시에 사용자가 원하는 History Group명으로 나뉘어집니다.
- ... 버튼 클릭 시 저장되어있던 Keyword들이 모두 노출될 수 있도록 합니다.

### 차후 보완이 필요한 부분
- 실시간 데이터베이스를 가져와 연동하는 작업
- 키워드 검색 시 사용자가 저장한 키워드 그룹 나오는 간이 검색 기능 작업
- 삭제 버튼 클릭 시 키워드 그룹 삭제 작업
- ... 토글 버튼 구현하여 사용자가 저장한 키워드 보여지는 기능 작업 

### 구현한 내용(체크박스로 나타내기)
- [x] 파비콘, 사이트 이름, 사이트 주소, 검색 키워드, 키워드 별 노출 횟수, 등록시간 표시
- [x] history item 영역 클릭 시 해당 url로 이동
- [ ] New Keyword+ 버튼을 클릭 시에 사용자가 원하는 History Group명으로 나뉘어짐
- [ ] keyword가 많을 시 최대 3개까지 노출하고 나머지는 (…)처리
- [ ] (…)버튼을 클릭 시 숨김 처리된 keyword가 모두 노출될 수 있도록 토글 처리

### 리뷰어가 집중적으로 바줬으면 하는 것
- 중복된 코드나 가독성이 낮은 변수명 및 코드가 있을 경우 개선점 관련하여 편히 의견 부탁드리겠습니다. 

### 관련 이슈
- feat: history item 기능 #9 
