### PR TITLE
fix: history item 렌더링 시 keyword 동기화

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "firebase": "^11.2.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router": "^7.1.1"
+        "react-router": "^7.1.1",
+        "react-router-dom": "^7.1.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
@@ -5820,9 +5821,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.1.1.tgz",
-      "integrity": "sha512-39sXJkftkKWRZ2oJtHhCxmoCrBCULr/HAH4IT5DHlgu/Q0FCPV0S4Lx+abjDTx/74xoZzNYDYbOZWlJjruyuDQ==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.1.3.tgz",
+      "integrity": "sha512-EezYymLY6Guk/zLQ2vRA8WvdUhWFEj5fcE3RfWihhxXBW7+cd1LsIiA3lmx+KCmneAGQuyBv820o44L2+TtkSA==",
       "license": "MIT",
       "dependencies": {
         "@types/cookie": "^0.6.0",
@@ -5841,6 +5842,22 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.1.3.tgz",
+      "integrity": "sha512-qQGTE+77hleBzv9SIUIkGRvuFBQGagW+TQKy53UTZAO/3+YFNBYvRsNIZ1GT17yHbc63FylMOdS+m3oUriF1GA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.1.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "firebase": "^11.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router": "^7.1.1"
+    "react-router": "^7.1.1",
+    "react-router-dom": "^7.1.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/src/History/DragAndDrop.jsx
+++ b/src/History/DragAndDrop.jsx
@@ -1,40 +1,45 @@
 import { useRef, useState } from "react";
 
+import sample from "../../sample.json";
 import NewKeywordButton from "../shared/NewKeywordButton";
 import KeywordGroup from "./KeywordGroup";
 
 export default function DragAndDrop() {
   const dragPosition = useRef();
-  const [list, setList] = useState([
+  const [historyGroups, setHistoryGroups] = useState([
     {
       id: 0,
-      name: "New Keyword Group",
-      keywords: ["exampleData", "keyword2", "deisp"],
-      count: [],
+      name: "New Keyword Group(default)",
+      histories: sample,
     },
   ]);
 
-  const startDrag = (event, groupIndex, keyword) => {
-    dragPosition.current = { groupIndex, keyword };
+  const startDrag = (historyGroupIndex, history) => {
+    dragPosition.current = {
+      historyGroupIndex: historyGroupIndex,
+      history: history,
+    };
   };
 
-  const drop = (event, groupIndex) => {
+  const drop = (event, nextHistoryGroupIndex, historyGroups) => {
     event.preventDefault();
 
-    const newList = [...list];
-    const { groupIndex: dragGroupIndex, keyword } = dragPosition.current;
+    const newHistoryGroups = [...historyGroups];
+    const { historyGroupIndex: prevHistoryGroupIndex, history: targetHistory } =
+      dragPosition.current;
 
-    newList[dragGroupIndex].keywords = newList[dragGroupIndex].keywords.filter(
-      (notKeyword) => notKeyword !== keyword
-    );
-    newList[groupIndex].keywords.push(keyword);
+    newHistoryGroups[prevHistoryGroupIndex].histories = newHistoryGroups[
+      prevHistoryGroupIndex
+    ].histories.filter((history) => history !== targetHistory);
+
+    newHistoryGroups[nextHistoryGroupIndex].histories.push(targetHistory);
 
     dragPosition.current = null;
-    setList(newList);
+    setHistoryGroups(newHistoryGroups);
   };
 
-  const newKeywordGroup = (groupName) => {
-    const newGroupId = list.length + 1;
+  const createHistoryGroup = (groupName) => {
+    const newGroupId = historyGroups.length + 1;
 
     if (groupName.trim() === false) {
       return null;
@@ -43,22 +48,22 @@ export default function DragAndDrop() {
     const newGroup = {
       id: newGroupId,
       name: groupName.trim(),
-      keywords: [],
+      histories: [],
     };
 
-    setList((prevList) => [...prevList, newGroup]);
+    setHistoryGroups((prev) => [...prev, newGroup]);
   };
 
   return (
     <>
-      <NewKeywordButton addGroup={newKeywordGroup} />
-      {list.map((item, index) => (
+      <NewKeywordButton addGroup={createHistoryGroup} />
+      {historyGroups.map((historyGroup, historyGroupIndex) => (
         <KeywordGroup
-          key={item.id}
-          groupName={item.name}
-          keywords={item.keywords}
-          onDragStart={(event, keyword) => startDrag(event, index, keyword)}
-          onDrop={(event) => drop(event, index)}
+          key={historyGroup.id}
+          groupName={historyGroup.name}
+          historyGroup={historyGroup}
+          onDragStart={(history) => startDrag(historyGroupIndex, history)}
+          onDrop={(event) => drop(event, historyGroupIndex, historyGroups)}
         />
       ))}
     </>

--- a/src/History/HistoryItem.jsx
+++ b/src/History/HistoryItem.jsx
@@ -1,74 +1,54 @@
 import PropTypes from "prop-types";
 
-import sample from "../../sample.json";
 import DeleteButton from "../shared/DeleteButton";
 import SearchKeyword from "./SearchKeyword";
 import SearchUrl from "./SearchUrl";
 import { TotalKeywordButton } from "./TotalKeywordButton";
 
-export default function HistoryItem({ keywords, onDragStart, onDrop }) {
-  const data = sample;
-  let siteUrl;
-  let siteName;
-  for (let i = 0; i < data.length; i++) {
-    siteUrl = data[i].siteTitle;
-  }
-  for (let i = 0; i < data.length; i++) {
-    siteName = data[i].url;
-  }
-
+export default function HistoryItem({ history, onDragStart }) {
   return (
-    <div
-      className="text-left w-[100%] shadow-md rounded-[10px]"
-      onDrop={onDrop}
-      onDragOver={(event) => event.preventDefault()}
+    <li
+      className="w-full flex flex-row justify-evenly items-center gap-[10px]"
+      draggable
+      onDragStart={() => onDragStart(history)}
     >
-      <div className="flex justify-center items-center gap-[10px] bg-none rounded-[10px] border px-[10px] ">
-        <ul className="w-full grid grid-cols-1 items-center gap-y-[15px] py-[3rem] rounded-lg">
-          {keywords.map((keywordItem, index) => (
-            <li
-              key={index}
-              className="w-full flex flex-row justify-evenly items-center gap-[10px]"
-              draggable
-              onDragStart={(event) => onDragStart(event, keywordItem)}
-            >
-              <label
-                htmlFor="yellow-checkbox"
-                className="flex justify-center items-center m-[10px]"
-              >
-                <input
-                  id="yellow-checkbox"
-                  type="checkbox"
-                  className="w-[20px] h-[20px]"
-                />
-              </label>
-              <div>
-                <div className="flex justify-between items-center gap-[30px] text-center">
-                  <SearchUrl
-                    title={siteUrl}
-                    url={siteName}
-                    time={"time"}
-                  />
-                </div>
-                <div className="flex justify-center items-center gap-[15px]">
-                  <SearchKeyword
-                    keywords={keywordItem}
-                    keywordsTotal={keywordItem.length}
-                  />
-                  <TotalKeywordButton />
-                  <DeleteButton />
-                </div>
-              </div>
-            </li>
-          ))}
-        </ul>
+      <label
+        htmlFor="yellow-checkbox"
+        className="flex justify-center items-center m-[10px]"
+      >
+        <input
+          id="yellow-checkbox"
+          type="checkbox"
+          className="w-[20px] h-[20px]"
+        />
+      </label>
+      <div>
+        <div className="flex justify-between items-center gap-[30px] text-center">
+          <SearchUrl
+            siteTitle={history.siteTitle}
+            url={history.url}
+            createdTime={history.createdTime}
+          />
+        </div>
+        <div className="flex justify-center items-center gap-[15px]">
+          {history.keywords.map(({ keyword, count }, index) => {
+            return (
+              <SearchKeyword
+                key={index}
+                keyword={keyword}
+                count={count}
+              />
+            );
+          })}
+          <TotalKeywordButton />
+          <DeleteButton />
+        </div>
       </div>
-    </div>
+    </li>
   );
 }
 
 HistoryItem.propTypes = {
-  keywords: PropTypes.array.isRequired,
+  history: PropTypes.object.isRequired,
   onDragStart: PropTypes.func.isRequired,
-  onDrop: PropTypes.func.isRequired,
 };

--- a/src/History/KeywordGroup.jsx
+++ b/src/History/KeywordGroup.jsx
@@ -5,20 +5,34 @@ import NewKeyword from "./NewKeyword";
 
 export default function KeywordGroup({
   groupName,
-  keywords,
+  historyGroup,
   onDragStart,
   onDrop,
 }) {
   return (
     <div className="newGroup">
-      <NewKeyword keyword={groupName} />
+      <NewKeyword groupName={groupName} />
       <div className="flex justify-center items-center">
-        <HistoryItem
-          groupName={groupName}
-          keywords={keywords}
-          onDragStart={onDragStart}
+        <div
+          className="text-left w-[100%] shadow-md rounded-[10px]"
           onDrop={onDrop}
-        />
+          onDragOver={(event) => event.preventDefault()}
+        >
+          <div className="flex justify-center items-center gap-[10px] bg-none rounded-[10px] border px-[10px] ">
+            <ul className="w-full grid grid-cols-1 items-center gap-y-[15px] py-[3rem] rounded-lg">
+              {historyGroup.histories.map((history, historyIdex) => {
+                return (
+                  <HistoryItem
+                    key={historyIdex}
+                    history={history}
+                    onDragStart={onDragStart}
+                    onDrop={onDrop}
+                  />
+                );
+              })}
+            </ul>
+          </div>
+        </div>
       </div>
     </div>
   );
@@ -26,7 +40,7 @@ export default function KeywordGroup({
 
 KeywordGroup.propTypes = {
   groupName: PropTypes.string.isRequired,
-  keywords: PropTypes.array.isRequired,
+  historyGroup: PropTypes.object.isRequired,
   onDragStart: PropTypes.func.isRequired,
   onDrop: PropTypes.func.isRequired,
 };

--- a/src/History/NewKeyword.jsx
+++ b/src/History/NewKeyword.jsx
@@ -1,11 +1,11 @@
 import PropTypes from "prop-types";
 
-export default function NewKeyword({ keyword }) {
+export default function NewKeyword({ groupName }) {
   return (
-    <h3 className="text-left text-xl font-semibold py-[10px]">{keyword}</h3>
+    <h3 className="text-left text-xl font-semibold py-[10px]">{groupName}</h3>
   );
 }
 
 NewKeyword.propTypes = {
-  keyword: PropTypes.string.isRequired,
+  groupName: PropTypes.string.isRequired,
 };

--- a/src/History/SearchKeyword.jsx
+++ b/src/History/SearchKeyword.jsx
@@ -1,17 +1,12 @@
 import PropTypes from "prop-types";
 
-import sample from "../../sample.json";
-
-export default function SearchKeyword({ keywords, keywordsTotal }) {
-  const sampleData = sample;
-  console.log(sampleData[0]);
-
+export default function SearchKeyword({ keyword, count }) {
   return (
     <>
       <p className="bg-[#333] text-[#fff] truncate border w-[100%] h-[40px] px-[3px] leading-[37px] text-sm text-center rounded-full">
-        {keywords}
+        {keyword}
         <span className="inline text-[#333] text-xs bg-[#fff] px-[5px] py-[1px] ml-[5px] rounded-full">
-          {keywordsTotal}
+          {count}
         </span>
       </p>
     </>
@@ -19,7 +14,6 @@ export default function SearchKeyword({ keywords, keywordsTotal }) {
 }
 
 SearchKeyword.propTypes = {
-  keywords: PropTypes.string,
-  keywordsTotal: PropTypes.number,
+  count: PropTypes.number,
   keyword: PropTypes.string,
 };

--- a/src/History/SearchUrl.jsx
+++ b/src/History/SearchUrl.jsx
@@ -1,8 +1,6 @@
 import PropTypes from "prop-types";
 
-import sample from "../../sample.json";
-
-export default function SearchUrl() {
+export default function SearchUrl({ siteTitle, url, createdTime }) {
   const options = {
     month: "numeric",
     day: "numeric",
@@ -10,24 +8,19 @@ export default function SearchUrl() {
     minute: "numeric",
   };
   const currentDate = new Intl.DateTimeFormat("ko-KR", options).format(
-    new Date(new Date().toISOString())
+    new Date(createdTime)
   );
-
-  const data = sample;
-
-  const siteUrl = data[4].url;
-  const siteTitle = data[4].siteTitle;
 
   return (
     <>
       <a
-        href={siteUrl}
+        href={url}
         className="flex items-center gap-[20px]"
         target="_blank"
       >
         <p className="w-[200px] truncate">{siteTitle}</p>
         <span className="w-[150px] text-[#aaa] truncate text-sm font-light">
-          {siteUrl}
+          {url}
         </span>
       </a>
       <span className="w-[120px] text-[#aaa] text-sm">{currentDate}</span>
@@ -36,7 +29,7 @@ export default function SearchUrl() {
 }
 
 SearchUrl.propTypes = {
-  title: PropTypes.string.isRequired,
+  siteTitle: PropTypes.string.isRequired,
   url: PropTypes.string.isRequired,
-  time: PropTypes.string.isRequired,
+  createdTime: PropTypes.string.isRequired,
 };


### PR DESCRIPTION
### 구현사진
![Jan-24-2025 12-17-13](https://github.com/user-attachments/assets/71620b58-bb8f-4235-ad34-1ab63c8d6335)

### 작업 내용
- 사용자는 각각 다른 history item을 볼 수 있습니다.
- 사용자는 history item에 해당하는 다양한 키워드들을 볼 수 있습니다.
- 기존의 드래그인드롭 기능과 호환됩니다.

### 기존 계획과 달라진 부분(+이유와 함께)

### 차후 보완이 필요한 부분
- 현재 sample 데이터를 사용하고 있습니다.
  - 위치 : src/History/DragAndDrop.jsx
- firebase 연동 후 실시간 데이터로 변경해야 합니다.

### 구현한 내용(체크박스로 나타내기)
- [X] history item 렌더링 시 keyword 동기화
- [X] 기존의 드래그인드롭 기능과의 호환성

### 리뷰어가 집중적으로 바줬으면 하는 것
- 기존 기능과 호환되는 지 여부

### 관련 이슈
Closes #13 
