### PR TITLE
feat: history item 내 다수 키워드 토글 처리

### DIFF
--- a/src/History/HistoryItem.jsx
+++ b/src/History/HistoryItem.jsx
@@ -1,7 +1,6 @@
 import PropTypes from "prop-types";
 
 import DeleteButton from "../shared/DeleteButton";
-import SearchKeyword from "./SearchKeyword";
 import SearchUrl from "./SearchUrl";
 import { TotalKeywordButton } from "./TotalKeywordButton";
 
@@ -31,16 +30,7 @@ export default function HistoryItem({ history, onDragStart }) {
           />
         </div>
         <div className="flex justify-center items-center gap-[15px]">
-          {history.keywords.map(({ keyword, count }, index) => {
-            return (
-              <SearchKeyword
-                key={index}
-                keyword={keyword}
-                count={count}
-              />
-            );
-          })}
-          <TotalKeywordButton />
+          <TotalKeywordButton history={history} />
           <DeleteButton />
         </div>
       </div>

--- a/src/History/TotalKeywordButton.jsx
+++ b/src/History/TotalKeywordButton.jsx
@@ -1,13 +1,47 @@
 import PropTypes from "prop-types";
 
-export function TotalKeywordButton({ keyword = "..." }) {
+import SearchKeyword from "./SearchKeyword";
+
+export function TotalKeywordButton({ history }) {
+  const numberOfKeywords = history.keywords.length;
+
   return (
-    <button className="w-[25%] truncate shadow p-[5px] rounded-[5px]">
-      {keyword}
-    </button>
+    <div
+      className={`${numberOfKeywords > 3 ? "collapse collapse-arrow bg-base-200" : "collapse bg-base-200"}`}
+    >
+      <input type="checkbox" />
+      <div className="collapse-title flex">
+        {history.keywords.map(({ keyword, count }, index) => {
+          return (
+            index < 3 && (
+              <SearchKeyword
+                key={index}
+                keyword={keyword}
+                count={count}
+              />
+            )
+          );
+        })}
+      </div>
+      <div className="collapse-content">
+        <div className="flex">
+          {history.keywords.map(({ keyword, count }, index) => {
+            return (
+              index >= 3 && (
+                <SearchKeyword
+                  key={index}
+                  keyword={keyword}
+                  count={count}
+                />
+              )
+            );
+          })}
+        </div>
+      </div>
+    </div>
   );
 }
 
 TotalKeywordButton.propTypes = {
-  keyword: PropTypes.func,
+  history: PropTypes.object,
 };

--- a/src/History/TotalKeywordButton.jsx
+++ b/src/History/TotalKeywordButton.jsx
@@ -6,9 +6,7 @@ export function TotalKeywordButton({ history }) {
   const numberOfKeywords = history.keywords.length;
 
   return (
-    <div
-      className={`${numberOfKeywords > 3 ? "collapse collapse-arrow bg-base-200" : "collapse bg-base-200"}`}
-    >
+    <div className="collapse collapse-arrow bg-base-200">
       <input type="checkbox" />
       <div className="collapse-title flex">
         {history.keywords.map(({ keyword, count }, index) => {
@@ -24,18 +22,24 @@ export function TotalKeywordButton({ history }) {
         })}
       </div>
       <div className="collapse-content">
-        <div className="flex">
-          {history.keywords.map(({ keyword, count }, index) => {
-            return (
-              index >= 3 && (
-                <SearchKeyword
-                  key={index}
-                  keyword={keyword}
-                  count={count}
-                />
-              )
-            );
-          })}
+        <div className="flex justify-center items-center">
+          {numberOfKeywords >= 4 ? (
+            history.keywords.map(({ keyword, count }, index) => {
+              return (
+                index >= 3 && (
+                  <SearchKeyword
+                    key={index}
+                    keyword={keyword}
+                    count={count}
+                  />
+                )
+              );
+            })
+          ) : (
+            <div className="text-sm text-gray-500 italic">
+              저장된 추가 키워드가 없습니다.
+            </div>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
### 구현사진

https://github.com/user-attachments/assets/628aea81-ccb4-4059-898d-c1f57c928fab

### 작업 내용
- 사용자가 저장한 키워드가 다수일 경우 일정 개수만 노출
- 나머지는 화살표 클릭 시 모든 키워드를 볼 수 있도록 구현
### 차후 보완이 필요한 부분
- 모든 UI 점검 시 style 변경 필요
### 구현한 내용(체크박스로 나타내기)
- [X] keyword가 많을 시 최대 3개까지 노출하고 나머지는 생략 처리
- [X] keyword가 3개 이하 시, 화살표 표시 X
- [X] 화살표 버튼을 클릭 시 생략 처리된 keyword가 모두 노출될 수 있도록 구현
### 리뷰어가 집중적으로 바줬으면 하는 것
- 디자인 통일성을 고려하여 3개 이하인 keyword 토글 클릭을 했을 시 "저장된 추가 키워드가 없습니다." 문구를 넣었습니다.
### 관련 이슈
feat: history item 내 다수 키워드 토글 처리 #15
