### PR TITLE
feat: firestore연동을 위해 group 스키마 기능 추가

### DIFF
--- a/src/firebase/getHistoryGroups.js
+++ b/src/firebase/getHistoryGroups.js
@@ -1,0 +1,44 @@
+import { collection, getDocs } from "firebase/firestore";
+
+import { db } from "./firebase";
+
+export async function getHistoryGroups(userId) {
+  const groups = [];
+
+  const groupsRef = collection(db, "users", userId, "groups");
+
+  const groupsQuerySnapshot = await getDocs(groupsRef);
+  groupsQuerySnapshot.forEach((groupDoc) => {
+    groups.push({
+      id: groupDoc.id,
+      name: groupDoc.data().name,
+      histories: [],
+    });
+  });
+
+  for (let i = 0; i < groups.length; i += 1) {
+    const groupId = groups[i].id;
+    const historiesRef = collection(
+      db,
+      "users",
+      userId,
+      "groups",
+      groupId,
+      "histories"
+    );
+
+    const historiesQuerySnapshot = await getDocs(historiesRef);
+    historiesQuerySnapshot.forEach((historyDoc) => {
+      groups[i].histories.push({
+        id: historyDoc.id,
+        faviconSrc: historyDoc.data().faviconSrc,
+        siteTitle: historyDoc.data().siteTitle,
+        url: historyDoc.data().url,
+        createdTime: historyDoc.data().createdTime,
+        keywords: historyDoc.data().keywords,
+      });
+    });
+  }
+
+  return groups;
+}

--- a/src/firebase/group.js
+++ b/src/firebase/group.js
@@ -1,0 +1,25 @@
+import { addDoc, collection, doc, updateDoc } from "firebase/firestore";
+
+import { db } from "./firebase";
+
+export async function addEmptyGroup(userId, groupName) {
+  const groupsRef = collection(db, "users", userId, "groups");
+
+  const groupDocRef = await addDoc(groupsRef, {
+    name: groupName,
+  });
+
+  return groupDocRef.id;
+}
+
+export async function updateGroupName(userId, groupId, newName) {
+  if (groupId === "default") {
+    throw Error("default group은 이름을 변경할 수 없습니다.");
+  }
+
+  const groupDocRef = doc(db, "users", userId, "groups", groupId);
+
+  await updateDoc(groupDocRef, {
+    name: newName,
+  });
+}


### PR DESCRIPTION
### 작업 내용
- addEmptyGroup를 새 그룹 생성 버튼을 클릭시 호출 하게 하면, firestore의 해당 사용자의 하위 컬렉션(groups)의 문서로 추가 됩니다.
  - 사용자 식별을 위해 userId와, 그룹을 만드는 데 필요한 그룹명의 제공이 필요합니다.
  - 새롭게 생성된 그룹의 id를 반환받을 수 있습니다.
- updateGroupName을 그룹명 변경하는 UI의 제출이 완료되었을 때 호출 하게 하면, 해당 group 문서의 name필드만 변경됩니다.
  - 사용자와 그룹 식별을 위해 각각의 id 제공이 필요하며, 바꿀 그룹명 제공도 필요합니다.
  - 해당 그룹의 id가 default일 경우 변경할 수 없습니다.
- getHistoryGroups를 website 입장시 호출하게 하면, firestore의 해당 사용자의 하위 컬렉션(groups)을 가져올 때 그 보다 더 하위 컬렉션(histories)들까지 모두 채워진 상태로 반환받을 수 있습니다.
  - 사용자 식별을 위해 userId 제공이 필요합니다.
  - 각각의 아이템(group, history)들은 고유한 id 필드를 가지고 있어, React에서 map등을 돌릴 때 사용할 수 있습니다.

<details>
<summary>참고 ) historyGroups은 다음과 같이 생겼습니다.</summary>

- 드래그드롭 전
  - <img width="998" alt="스크린샷 2025-01-28 오후 9 03 43" src="https://github.com/user-attachments/assets/9a6e6785-9c83-4c1f-80b2-6719c24f6faa" />

- 드래그드롭 후
  - <img width="1002" alt="스크린샷 2025-01-28 오후 9 04 30" src="https://github.com/user-attachments/assets/68ae9577-cbb6-4c6a-8779-0882fa3a8b2e" />

</details>

### 기존 계획과 달라진 부분(+이유와 함께)
- 기존에 default group의 id가 "new-keyword-group"로 되어 있어 보다 직관성을 위해 "default"로 변경하였습니다.
- 실제로 필요한 부분에서 호출하는 부분까지 함께 작업하려 했으나, 미팅에서 다음과 같이 논의되었습니다. 같은 파일을 수정하고 있는 기능이 있으므로 차후 통합하는 시간을 갖고 그때 통합하기로 결정되었습니다.

### 차후 보완이 필요한 부분
- 해당 함수들을 호출하는 상황이 현재와 달라질 수 있어 상황에 맞춰 빠른 보완작업이 진행될 예정입니다.
- 예외 상황 대응

### 구현한 내용(체크박스로 나타내기)
- [X] group 이름을 변경할 수 있는 기능
- [X] 새로운 group을 추가할 수 있는 기능
- [X] groups를 가져올 때, 하위 컬렉션(histories)들을 채워서 가져오는 기능

### 리뷰어가 집중적으로 바줬으면 하는 것
- 위에서 아래로 읽었을 경우 가독성
- pull 받아서 테스트시 기능적인 보완 부분 유무

### 관련 이슈
Closes #19 
