### PR TITLE
feat: 드래그앤드롭 이후 DB와 동기화 시키는 기능 추가

### DIFF
--- a/src/firebase/afterDragAndDrop.js
+++ b/src/firebase/afterDragAndDrop.js
@@ -1,0 +1,97 @@
+import {
+  collection,
+  deleteDoc,
+  doc,
+  getDoc,
+  getDocs,
+  setDoc,
+} from "firebase/firestore";
+
+import { db } from "./firebase";
+
+async function getHistoryIdMapByDB(userId) {
+  const historyIdMap = new Map();
+
+  const groupIds = [];
+
+  const groupsRef = collection(db, "users", userId, "groups");
+  const groupsQuerySnapshot = await getDocs(groupsRef);
+  groupsQuerySnapshot.forEach((groupDoc) => {
+    groupIds.push(groupDoc.id);
+  });
+
+  for (const groupId of groupIds) {
+    const historiesRef = collection(
+      db,
+      "users",
+      userId,
+      "groups",
+      groupId,
+      "histories"
+    );
+
+    const historiesQuerySnapshot = await getDocs(historiesRef);
+    historiesQuerySnapshot.forEach((historyDoc) => {
+      historyIdMap.set(historyDoc.id, groupId);
+    });
+  }
+
+  return historyIdMap;
+}
+
+export async function updateGroupsAndHistoriesAfterDragAndDrop(
+  userId,
+  updatedHistoryGroups
+) {
+  const originHistoryIdMap = await getHistoryIdMapByDB(userId);
+
+  for (let i = 0; i < updatedHistoryGroups.length; i += 1) {
+    const updatedGroup = updatedHistoryGroups[i];
+    const updatedGroupId = updatedGroup.id;
+    const historiesByUpdatedGroup = updatedGroup.histories;
+
+    const historiesRef = collection(
+      db,
+      "users",
+      userId,
+      "groups",
+      updatedGroupId,
+      "histories"
+    );
+
+    for (const history of historiesByUpdatedGroup) {
+      const historyId = history.id;
+
+      const historyDocRef = doc(
+        db,
+        "users",
+        userId,
+        "groups",
+        updatedGroupId,
+        "histories",
+        historyId
+      );
+      const historyDocSnap = await getDoc(historyDocRef);
+
+      if (!historyDocSnap.exists()) {
+        const originGroupId = originHistoryIdMap.get(historyId);
+        const originHistoryDocRef = doc(
+          db,
+          "users",
+          userId,
+          "groups",
+          originGroupId,
+          "histories",
+          historyId
+        );
+
+        const originHistoryDocSnap = await getDoc(originHistoryDocRef);
+        const originHistoryData = originHistoryDocSnap.data();
+
+        await deleteDoc(originHistoryDocRef);
+
+        await setDoc(doc(historiesRef, historyId), originHistoryData);
+      }
+    }
+  }
+}


### PR DESCRIPTION
### 작업 내용
- updateGroupsAndHistoriesAfterDragAndDrop 함수 호출 시 다음과 같은 작업이 시작됩니다.
- 새로 업데이트 된 historyGroups를 기반으로, 데이터베이스의 history의 위치를 변경 합니다.
- 기존 소속된 group에서 해당 history를 삭제합니다.
- 새롭게 소속된 group에서 해당 history를 추가합니다.
- 이때 history id는 유지합니다.
<details>
<summary>참고 ) historyGroups은 다음과 같이 생겼습니다.</summary>

- 드래그드롭 전
  - <img width="998" alt="스크린샷 2025-01-28 오후 9 03 43" src="https://github.com/user-attachments/assets/9a6e6785-9c83-4c1f-80b2-6719c24f6faa" />

- 드래그드롭 후
  - <img width="1002" alt="스크린샷 2025-01-28 오후 9 04 30" src="https://github.com/user-attachments/assets/68ae9577-cbb6-4c6a-8779-0882fa3a8b2e" />

</details>

### 기존 계획과 달라진 부분(+이유와 함께)
- 실제로 필요한 부분에서 호출하는 부분까지 함께 작업하려 했으나, 미팅에서 다음과 같이 논의되었습니다. 같은 파일을 수정하고 있는 기능이 있으므로 차후 통합하는 시간을 갖고 그때 통합하기로 결정되었습니다.

### 차후 보완이 필요한 부분
- 해당 함수들을 호출하는 상황이 현재와 달라질 수 있어 상황에 맞춰 빠른 보완작업이 진행될 예정입니다.
- 예외 상황 대응

### 구현한 내용(체크박스로 나타내기)
- [X] 변경된 historyGroups가 데이터베이스에 반영된다.

### 리뷰어가 집중적으로 바줬으면 하는 것
- 위에서 아래로 읽었을 경우 가독성
- pull 받아서 테스트시 기능적인 보완 부분 유무

### 관련 이슈
Closes #22 

