### PR TITLE
feat: webSite 로그인 기능 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,7 @@ import { Route, Routes } from "react-router-dom";
 import "./App.css";
 import Home from "./Home";
 import Initial from "./shared/Initial";
-import Login from "./shared/login";
+import Login from "./shared/Login";
 
 const queryClient = new QueryClient();
 

--- a/src/shared/Login.jsx
+++ b/src/shared/Login.jsx
@@ -1,8 +1,30 @@
-import { Link } from "react-router-dom";
+import { GoogleAuthProvider, signInWithPopup } from "firebase/auth";
+import { getAuth } from "firebase/auth";
 
 import imgUrl from "../assets/sticky-seacher-logo.png";
+import { app } from "../firebase/firebase";
 
 export default function Login() {
+  const auth = getAuth(app);
+  const authData = async () => {
+    const provider = new GoogleAuthProvider();
+
+    const data = await signInWithPopup(auth, provider);
+
+    const user = data.user;
+    const email = user.email;
+    const accessToken = user.accessToken;
+
+    localStorage.setItem("userEmail", email);
+    localStorage.setItem("accessToken", accessToken);
+
+    const userEmail = window.localStorage.getItem("userEmail");
+    const userAccessToken = window.localStorage.getItem("accessToken");
+
+    document.write(userEmail);
+    document.write(userAccessToken);
+  };
+
   return (
     <div className="border rounded-[20px] h-screen flex flex-col justify-center items-center shadow">
       <img
@@ -13,12 +35,12 @@ export default function Login() {
       <h1 className="text-5xl font-thin mt-[30px] mb-[80px]">
         Sticky Searcher
       </h1>
-      <Link
-        to="/"
+      <button
+        onClick={authData}
         className="block text-2xl w-[45%] h-[70px] leading-[70px] flex-col align-center border rounded-lg shadow"
       >
         Google Login
-      </Link>
+      </button>
     </div>
   );
 }

--- a/src/shared/Login.jsx
+++ b/src/shared/Login.jsx
@@ -1,5 +1,4 @@
-import { GoogleAuthProvider, signInWithPopup } from "firebase/auth";
-import { getAuth } from "firebase/auth";
+import { GoogleAuthProvider, getAuth, signInWithPopup } from "firebase/auth";
 
 import imgUrl from "../assets/sticky-seacher-logo.png";
 import { app } from "../firebase/firebase";
@@ -16,13 +15,12 @@ export default function Login() {
     const accessToken = user.accessToken;
 
     localStorage.setItem("userEmail", email);
-    localStorage.setItem("accessToken", accessToken);
+    localStorage.setItem("userAccessToken", accessToken);
 
+    // eslint-disable-next-line no-unused-vars
     const userEmail = window.localStorage.getItem("userEmail");
-    const userAccessToken = window.localStorage.getItem("accessToken");
-
-    document.write(userEmail);
-    document.write(userAccessToken);
+    // eslint-disable-next-line no-unused-vars
+    const userAccessToken = window.localStorage.getItem("userAccessToken");
   };
 
   return (

--- a/src/shared/Login.jsx
+++ b/src/shared/Login.jsx
@@ -17,10 +17,8 @@ export default function Login() {
     localStorage.setItem("userEmail", email);
     localStorage.setItem("userAccessToken", accessToken);
 
-    // eslint-disable-next-line no-unused-vars
-    const userEmail = window.localStorage.getItem("userEmail");
-    // eslint-disable-next-line no-unused-vars
-    const userAccessToken = window.localStorage.getItem("userAccessToken");
+    window.localStorage.getItem("userEmail");
+    window.localStorage.getItem("userAccessToken");
   };
 
   return (


### PR DESCRIPTION
### 구현사진
https://github.com/user-attachments/assets/74ff060e-aa29-4d6e-bb19-e9a455452ea3

### 작업 내용
- 웹사이트 로그인 페이지내에서 로그인 버튼 클릭 시 구글 로그인 연동
- 로그인 버튼 클릭 후 사용자 이메일, 엑세스 토큰 출력

### 기존 계획과 달라진 부분(+이유와 함께)
- 기존 : extension 로그인 진행 후 website에서 로그인 진행할 시  사용자 식별할 수 있게끔 하는 단계 
- 변경 : website 로그인 진행 후  extension 사용자 식별을 위해 검증 단계 

### 구현한 내용(체크박스로 나타내기)
- [x] 로그인 버튼 클릭 시 구글 로그인 연동
- [x] 사용자 식별 이메일 , 토큰 값 가져오기

### 리뷰어가 집중적으로 바줬으면 하는 것
- 로그인 시  받아오는 정보에 대한 변수명 관련하여 적합한지 불필요한 코드는 없는지 확인 부탁드립니다:)

### 관련 이슈
- feat: webSite 로그인 기능 구현 #24 