### PR TITLE
feat: webSite 로그인 완료 후 History Page redirection

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import { Route, Routes } from "react-router-dom";
 
 import "./App.css";
 import Home from "./Home";
+import ProtectedRoute from "./ProtectedRoute";
 import { UserIdProvider } from "./context/userIdContext";
 import Initial from "./shared/Initial";
 import Login from "./shared/Login";
@@ -16,7 +17,7 @@ function App() {
         <Routes>
           <Route
             path="/"
-            element={<Home />}
+            element={<ProtectedRoute element={<Home />} />}
           />
           <Route
             path="/Initial"

--- a/src/ProtectedRoute.jsx
+++ b/src/ProtectedRoute.jsx
@@ -1,0 +1,26 @@
+import PropTypes from "prop-types";
+import { Navigate } from "react-router-dom";
+
+import { useUserId } from "./context/userIdContext";
+
+const ProtectedRoute = ({ element }) => {
+  const { userId } = useUserId();
+  const accessToken = localStorage.getItem("userAccessToken");
+
+  if (userId || accessToken) {
+    return <>{element}</>;
+  }
+
+  return (
+    <Navigate
+      to="/login"
+      replace
+    />
+  );
+};
+
+export default ProtectedRoute;
+
+ProtectedRoute.propTypes = {
+  element: PropTypes.element.isRequired,
+};

--- a/src/shared/Login.jsx
+++ b/src/shared/Login.jsx
@@ -1,4 +1,5 @@
 import { GoogleAuthProvider, getAuth, signInWithPopup } from "firebase/auth";
+import { useNavigate } from "react-router-dom";
 
 import imgUrl from "../assets/sticky-seacher-logo.png";
 import { useUserId } from "../context/userIdContext";
@@ -7,6 +8,7 @@ import { addNewUserAndDefaultGroup, getUser } from "../firebase/user";
 
 export default function Login() {
   const { setUserId } = useUserId();
+  const navigate = useNavigate();
 
   const auth = getAuth(app);
   const authData = async () => {
@@ -27,6 +29,8 @@ export default function Login() {
 
     localStorage.setItem("userEmail", email);
     localStorage.setItem("userAccessToken", accessToken);
+
+    navigate("/");
   };
 
   return (


### PR DESCRIPTION
### 구현사진
https://github.com/user-attachments/assets/74270cb2-9dbe-4a0b-a342-fe763812b77f

### 작업 내용
- 사용자가 History Page 버튼 클릭 시 로그인 정보가 없다면 Login페이지를 표시해 줘야합니다.
- 사용자의 이메일 및 토큰 값과 같이 사용자 식별 여부가 판단된다면 Login페이지가 아닌 곧바로 History페이지로 redirection 되는 로직구현입니다.
- 쿠키 삭제하여 사용자의 이메일 및 토큰 값이 없다면 Login 페이지로 이동되어야합니다.
- 새로고침하여도 로컬스토리지의 사용자의 이메일, 토큰값을 저장된 걸 기억하고 사용자의 History페이지로 들어와져야합니다. 
- 현재 locahost:5173이지만 배포 후에 최상단 경로여도 사용자의 식별이 어려운 경우 Login페이지로 이동되어야합니다.

### 구현한 내용(체크박스로 나타내기)
- [x] 사용자의 로그인 식별 확인 후 redirection되는 페이지를 History페이지로 이동
- [x] 사용자의 로그인 식별이 어려운 경우 Login페이지로 이동
- [x] 최상단 경로여도 사용자의 식별이 어려운 경우 Login페이지로 이동
- [x] 새로고침 하여도 사용자의 식별 확인이 된 경우라면 History페이지 유지

### 리뷰어가 집중적으로 바줬으면 하는 것
- 변수명 및 코드 개선점이 있다면 가감없이 편히 의견 부탁드립니다(_ _)

### 관련 이슈
- feat: webSite 로그인 완료 후 History Page redirection #28 
