### PR TITLE
feat: history 및 group 삭제 기능

### DIFF
--- a/src/History/DragAndDrop.jsx
+++ b/src/History/DragAndDrop.jsx
@@ -76,6 +76,7 @@ export default function DragAndDrop() {
           key={historyGroup.id}
           addedGroupName={historyGroups}
           setAddedGroupName={setHistoryGroups}
+          setHistoryGroups={setHistoryGroups}
           groupName={historyGroup.name}
           historyGroup={historyGroup}
           onDragStart={(history) => startDrag(historyGroupIndex, history)}

--- a/src/History/HistoryItem.jsx
+++ b/src/History/HistoryItem.jsx
@@ -1,10 +1,18 @@
 import PropTypes from "prop-types";
 
+import { useUserId } from "../context/userIdContext";
+import { deleteHistory } from "../firebase/history";
 import DeleteButton from "../shared/DeleteButton";
 import SearchUrl from "./SearchUrl";
 import { TotalKeywordButton } from "./TotalKeywordButton";
 
-export default function HistoryItem({ history, onDragStart }) {
+export default function HistoryItem({
+  history,
+  onDragStart,
+  groupId,
+  setHistoryGroups,
+}) {
+  const { userId } = useUserId();
   return (
     <li
       className="flex flex-row justify-evenly w-[100%] items-center gap-[10px]"
@@ -24,7 +32,28 @@ export default function HistoryItem({ history, onDragStart }) {
             <TotalKeywordButton history={history} />
           </div>
         </div>
-        <DeleteButton />
+        <DeleteButton
+          onClick={() => {
+            const targetHistoryId = history.id;
+            deleteHistory(userId, groupId, targetHistoryId);
+            setHistoryGroups((prevGroups) => {
+              const updated = prevGroups.map((prevGroup) => {
+                if (prevGroup.id === groupId) {
+                  return {
+                    ...prevGroup,
+                    histories: prevGroup.histories.filter(
+                      (history) => history.id !== targetHistoryId
+                    ),
+                  };
+                } else {
+                  return prevGroup;
+                }
+              });
+
+              return updated;
+            });
+          }}
+        />
       </div>
     </li>
   );
@@ -33,4 +62,6 @@ export default function HistoryItem({ history, onDragStart }) {
 HistoryItem.propTypes = {
   history: PropTypes.object.isRequired,
   onDragStart: PropTypes.func.isRequired,
+  groupId: PropTypes.string.isRequired,
+  setHistoryGroups: PropTypes.func.isRequired,
 };

--- a/src/History/KeywordGroup.jsx
+++ b/src/History/KeywordGroup.jsx
@@ -1,5 +1,7 @@
 import PropTypes from "prop-types";
 
+import { useUserId } from "../context/userIdContext";
+import { deleteGroup } from "../firebase/group";
 import ChangeGroupName from "./ChangeGroupName";
 import HistoryItem from "./HistoryItem";
 
@@ -12,6 +14,7 @@ export default function KeywordGroup({
   onDrop,
   setHistoryGroups,
 }) {
+  const { userId } = useUserId();
   return (
     <div className="newGroup h-full relative">
       <div>
@@ -42,7 +45,16 @@ export default function KeywordGroup({
             </ul>
           </div>
         </div>
-        <button className=" w-DelBtnW h-DelBtnH rounded-sm hover:bg-[#ddd] absolute right-[10px] top-[10px] text-subPrimary1">
+        <button
+          onClick={() => {
+            const targetGroupId = historyGroup.id;
+            deleteGroup(userId, targetGroupId);
+            setHistoryGroups((prevGroups) =>
+              prevGroups.filter((preGroup) => preGroup.id !== targetGroupId)
+            );
+          }}
+          className=" w-DelBtnW h-DelBtnH rounded-sm hover:bg-[#ddd] absolute right-[10px] top-[10px] text-subPrimary1"
+        >
           X
         </button>
       </div>

--- a/src/History/KeywordGroup.jsx
+++ b/src/History/KeywordGroup.jsx
@@ -15,6 +15,7 @@ export default function KeywordGroup({
   setHistoryGroups,
 }) {
   const { userId } = useUserId();
+  const targetGroupId = historyGroup.id;
   return (
     <div className="newGroup h-full relative">
       <div>
@@ -45,18 +46,22 @@ export default function KeywordGroup({
             </ul>
           </div>
         </div>
-        <button
-          onClick={() => {
-            const targetGroupId = historyGroup.id;
-            deleteGroup(userId, targetGroupId);
-            setHistoryGroups((prevGroups) =>
-              prevGroups.filter((preGroup) => preGroup.id !== targetGroupId)
-            );
-          }}
-          className=" w-DelBtnW h-DelBtnH rounded-sm hover:bg-[#ddd] absolute right-[10px] top-[10px] text-subPrimary1"
-        >
-          X
-        </button>
+        {targetGroupId !== "default" && (
+          <button
+            onClick={() => {
+              if (targetGroupId === "default") {
+                return;
+              }
+              deleteGroup(userId, targetGroupId);
+              setHistoryGroups((prevGroups) =>
+                prevGroups.filter((preGroup) => preGroup.id !== targetGroupId)
+              );
+            }}
+            className=" w-DelBtnW h-DelBtnH rounded-sm hover:bg-[#ddd] absolute right-[10px] top-[10px] text-subPrimary1"
+          >
+            X
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/History/KeywordGroup.jsx
+++ b/src/History/KeywordGroup.jsx
@@ -10,6 +10,7 @@ export default function KeywordGroup({
   historyGroup,
   onDragStart,
   onDrop,
+  setHistoryGroups,
 }) {
   return (
     <div className="newGroup h-full relative">
@@ -33,6 +34,8 @@ export default function KeywordGroup({
                     history={history}
                     onDragStart={onDragStart}
                     onDrop={onDrop}
+                    groupId={historyGroup.id}
+                    setHistoryGroups={setHistoryGroups}
                   />
                 );
               })}
@@ -54,4 +57,5 @@ KeywordGroup.propTypes = {
   historyGroup: PropTypes.object.isRequired,
   onDragStart: PropTypes.func.isRequired,
   onDrop: PropTypes.func.isRequired,
+  setHistoryGroups: PropTypes.func.isRequired,
 };

--- a/src/firebase/group.js
+++ b/src/firebase/group.js
@@ -1,4 +1,11 @@
-import { addDoc, collection, doc, updateDoc } from "firebase/firestore";
+import {
+  addDoc,
+  collection,
+  deleteDoc,
+  doc,
+  getDocs,
+  updateDoc,
+} from "firebase/firestore";
 
 import { db } from "./firebase";
 
@@ -22,4 +29,43 @@ export async function updateGroupName(userId, groupId, newName) {
   await updateDoc(groupDocRef, {
     name: newName,
   });
+}
+
+export async function deleteGroup(userId, groupId) {
+  if (groupId === "default") {
+    throw Error("default group은 삭제할 수 없습니다.");
+  }
+
+  const historyIds = [];
+
+  const historiesRef = collection(
+    db,
+    "users",
+    userId,
+    "groups",
+    groupId,
+    "histories"
+  );
+  const historiesQuerySnapshot = await getDocs(historiesRef);
+  historiesQuerySnapshot.forEach((historyDoc) => {
+    historyIds.push(historyDoc.id);
+  });
+
+  for (const historyId of historyIds) {
+    const historyDocRef = doc(
+      db,
+      "users",
+      userId,
+      "groups",
+      groupId,
+      "histories",
+      historyId
+    );
+
+    await deleteDoc(historyDocRef);
+  }
+
+  const GroupDocRef = doc(db, "users", userId, "groups", groupId);
+
+  await deleteDoc(GroupDocRef);
 }

--- a/src/firebase/history.js
+++ b/src/firebase/history.js
@@ -1,0 +1,17 @@
+import { deleteDoc, doc } from "firebase/firestore";
+
+import { db } from "./firebase";
+
+export async function deleteHistory(userId, groupId, historyId) {
+  const historyDocRef = doc(
+    db,
+    "users",
+    userId,
+    "groups",
+    groupId,
+    "histories",
+    historyId
+  );
+
+  await deleteDoc(historyDocRef);
+}

--- a/src/shared/DeleteButton.jsx
+++ b/src/shared/DeleteButton.jsx
@@ -1,8 +1,13 @@
+import PropTypes from "prop-types";
+
 import iconUrl from "../assets/delete_icon.png";
 
-export default function DeleteButton() {
+export default function DeleteButton({ onClick }) {
   return (
-    <button className="flex justify-center items-center hover:bg-[#eee] rounded-full text-Primary w-DelBtnW h-DelBtnH">
+    <button
+      onClick={onClick}
+      className="flex justify-center items-center hover:bg-[#eee] rounded-full text-Primary w-DelBtnW h-DelBtnH"
+    >
       <img
         src={iconUrl}
         alt="sticky-seacher-logo"
@@ -11,3 +16,7 @@ export default function DeleteButton() {
     </button>
   );
 }
+
+DeleteButton.propTypes = {
+  onClick: PropTypes.func.isRequired,
+};


### PR DESCRIPTION
### 구현사진
https://github.com/user-attachments/assets/005b3ae1-6811-40d3-810e-cb4a68e26bb2

### 작업 내용
- 휴지통 버튼을 클릭하면, 현재 로그인 되어있는 userId와, 소속된 groupId, 선택된 historyId를 제공하여 firestore에서 해당 [history item]삭제 작업을 시행합니다. 프론트엔드에서도 삭제된 상태가 업데이트 됩니다.
- 그룹 명 옆의 X 버튼을 클릭하면, 현재 로그인 되어있는 userId와, 선택된 groupId를 제공하여 firestore에서 해당 [group] 삭제 작업을 시행합니다. groups 콜렉션에는 하위 콜렉션인 histories가 있으므로, 선택된 group 문서의 하위 history 문서들도 모두 삭제됩니다. default group은 삭제되면 안되므로 삭제가 진행되지 않습니다. 프론트엔드에서도 삭제된 상태가 업데이트 됩니다.

### 기존 계획과 달라진 부분(+이유와 함께)
- default group은 삭제가 가능하면 안되므로, default group 옆에는 삭제 버튼이 렌더링되지 않도록 수정했습니다.

### 차후 보완이 필요한 부분
현재 상태가 다소 많이 props drilling 되고 있는 것 같습니다. useContext도 사용할 수 있으나 리렌더링 관리 용이성을 위해 추후 상태관리 라이브러리 도입을 논의했으면 좋겠습니다. 

### 구현한 내용(체크박스로 나타내기)
- [X] history Item 삭제 버튼 클릭 시, 프론트엔드에서 삭제되는 기능
- [X] history Item 삭제 버튼 클릭 시, 벡엔드에서 삭제되는 기능
- [X] 하나의 group 삭제 버튼 클릭 시, 프론트엔드에서 삭제되는 기능
- [X] 하나의 group 삭제 버튼 클릭 시, 벡엔드에서 삭제되는 기능

### 리뷰어가 집중적으로 바줬으면 하는 것
- pull 받아서 테스트시 기능적인 보완 부분 유무

### 관련 이슈
Closes #32 
