### PR TITLE
feat: 서버 상태관리를 위해 tanstack query로 전환

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@
 
 <div align="left">
   <img src="https://img.shields.io/badge/React-61DAFB?style=for-the-badge&logo=React&logoColor=white">
+  <img src="https://img.shields.io/badge/TanStack Query-FF4154?style=for-the-badge&logo=reactquery&logoColor=white" />
   <img src="https://img.shields.io/badge/React Router-CA4245?style=for-the-badge&logo=react&logoColor=white" />
   <img src="https://img.shields.io/badge/Tailwind CSS-06B6D4?style=for-the-badge&logo=tailwindcss&logoColor=white" />
   <img src="https://img.shields.io/badge/DaisyUI-1AD1A5?style=for-the-badge&logo=DaisyUI&logoColor=white">

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@tanstack/react-query": "^5.64.1",
+        "@tanstack/react-query-devtools": "^5.81.5",
         "firebase": "^11.2.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -2138,9 +2139,19 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.64.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.64.1.tgz",
-      "integrity": "sha512-978Wx4Wl4UJZbmvU/rkaM9cQtXXrbhK0lsz/UZhYIbyKYA8E4LdomTwyh2GHZ4oU0BKKoDH4YlKk2VscCUgNmg==",
+      "version": "5.81.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.81.5.tgz",
+      "integrity": "sha512-ZJOgCy/z2qpZXWaj/oxvodDx07XcQa9BF92c0oINjHkoqUPsmm3uG08HpTaviviZ/N9eP1f9CM7mKSEkIo7O1Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.81.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.81.2.tgz",
+      "integrity": "sha512-jCeJcDCwKfoyyBXjXe9+Lo8aTkavygHHsUHAlxQKKaDeyT0qyQNLKl7+UyqYH2dDF6UN/14873IPBHchcsU+Zg==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2148,18 +2159,35 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.64.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.64.1.tgz",
-      "integrity": "sha512-vW5ggHpIO2Yjj44b4sB+Fd3cdnlMJppXRBJkEHvld6FXh3j5dwWJoQo7mGtKI2RbSFyiyu/PhGAy0+Vv5ev9Eg==",
+      "version": "5.81.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.81.5.tgz",
+      "integrity": "sha512-lOf2KqRRiYWpQT86eeeftAGnjuTR35myTP8MXyvHa81VlomoAWNEd8x5vkcAfQefu0qtYCvyqLropFZqgI2EQw==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.64.1"
+        "@tanstack/query-core": "5.81.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.81.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.81.5.tgz",
+      "integrity": "sha512-lCGMu4RX0uGnlrlLeSckBfnW/UV+KMlTBVqa97cwK7Z2ED5JKnZRSjNXwoma6sQBTJrcULvzgx2K6jEPvNUpDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.81.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.81.5",
         "react": "^18 || ^19"
       }
     },

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.64.1",
+    "@tanstack/react-query-devtools": "^5.81.5",
     "firebase": "^11.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { Route, Routes } from "react-router-dom";
 
 import "./App.css";
@@ -28,6 +29,7 @@ function App() {
             element={<Login />}
           />
         </Routes>
+        <ReactQueryDevtools />
       </QueryClientProvider>
     </UserIdProvider>
   );

--- a/src/History/ChangeGroupName.jsx
+++ b/src/History/ChangeGroupName.jsx
@@ -2,16 +2,15 @@ import PropTypes from "prop-types";
 import { useEffect, useState } from "react";
 
 import { useUserId } from "../context/userIdContext";
-import { updateGroupName } from "../firebase/group";
+import useGroups from "../hooks/useGroups";
 import useHistoryGroups from "../hooks/useHistoryGroups";
 
-export default function ChangeGroupName({
-  initialGroupName,
-  setAddedGroupName,
-}) {
+export default function ChangeGroupName({ initialGroupName }) {
   const [inputText, setInputText] = useState(initialGroupName);
   const [isChangeName, setIsChangeName] = useState(true);
   const [prevGroupName, setPrevGroupName] = useState("");
+
+  const { updateGroupNameMutation } = useGroups();
 
   const {
     historyGroupsQuery: { data: historyGroups },
@@ -46,9 +45,8 @@ export default function ChangeGroupName({
       const groupId = copiedPrevGroupName[findGroupIndex].id;
       const groupName = copiedPrevGroupName[findGroupIndex].name;
 
-      await updateGroupName(userId, groupId, groupName);
+      updateGroupNameMutation.mutate({ userId, groupId, groupName });
 
-      setAddedGroupName(copiedPrevGroupName);
       setIsChangeName(false);
     }
   }
@@ -86,5 +84,4 @@ export default function ChangeGroupName({
 
 ChangeGroupName.propTypes = {
   initialGroupName: PropTypes.string.isRequired,
-  setAddedGroupName: PropTypes.func.isRequired,
 };

--- a/src/History/ChangeGroupName.jsx
+++ b/src/History/ChangeGroupName.jsx
@@ -1,7 +1,6 @@
 import PropTypes from "prop-types";
 import { useEffect, useState } from "react";
 
-import { useUserId } from "../context/userIdContext";
 import useGroups from "../hooks/useGroups";
 import useHistoryGroups from "../hooks/useHistoryGroups";
 
@@ -21,8 +20,6 @@ export default function ChangeGroupName({ initialGroupName }) {
   const findGroupIndex = copiedPrevGroupName.findIndex(
     (group) => group.name === prevGroupName
   );
-
-  const { userId } = useUserId();
 
   useEffect(() => {
     if (inputText === defaultGroupName) {
@@ -45,7 +42,7 @@ export default function ChangeGroupName({ initialGroupName }) {
       const groupId = copiedPrevGroupName[findGroupIndex].id;
       const groupName = copiedPrevGroupName[findGroupIndex].name;
 
-      updateGroupNameMutation.mutate({ userId, groupId, groupName });
+      updateGroupNameMutation.mutate({ groupId, groupName });
 
       setIsChangeName(false);
     }

--- a/src/History/ChangeGroupName.jsx
+++ b/src/History/ChangeGroupName.jsx
@@ -3,18 +3,22 @@ import { useEffect, useState } from "react";
 
 import { useUserId } from "../context/userIdContext";
 import { updateGroupName } from "../firebase/group";
+import useHistoryGroups from "../hooks/useHistoryGroups";
 
 export default function ChangeGroupName({
   initialGroupName,
-  addedGroupName,
   setAddedGroupName,
 }) {
   const [inputText, setInputText] = useState(initialGroupName);
   const [isChangeName, setIsChangeName] = useState(true);
   const [prevGroupName, setPrevGroupName] = useState("");
 
-  const defaultGroupName = addedGroupName[0].name;
-  const copiedPrevGroupName = [...addedGroupName];
+  const {
+    historyGroupsQuery: { data: historyGroups },
+  } = useHistoryGroups();
+
+  const defaultGroupName = historyGroups[0].name;
+  const copiedPrevGroupName = [...historyGroups];
   const findGroupIndex = copiedPrevGroupName.findIndex(
     (group) => group.name === prevGroupName
   );
@@ -82,6 +86,5 @@ export default function ChangeGroupName({
 
 ChangeGroupName.propTypes = {
   initialGroupName: PropTypes.string.isRequired,
-  addedGroupName: PropTypes.array.isRequired,
   setAddedGroupName: PropTypes.func.isRequired,
 };

--- a/src/History/DragAndDrop.jsx
+++ b/src/History/DragAndDrop.jsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useRef } from "react";
 
 import { useUserId } from "../context/userIdContext";
 import useGroups from "../hooks/useGroups";
@@ -8,7 +8,7 @@ import KeywordGroup from "./KeywordGroup";
 
 export default function DragAndDrop() {
   const dragPosition = useRef();
-  const [, setHistoryGroups] = useState([]);
+
   const { userId } = useUserId();
 
   const {
@@ -56,7 +56,6 @@ export default function DragAndDrop() {
       {historyGroups.map((historyGroup, historyGroupIndex) => (
         <KeywordGroup
           key={historyGroup.id}
-          setHistoryGroups={setHistoryGroups}
           groupName={historyGroup.name}
           historyGroup={historyGroup}
           onDragStart={(history) => startDrag(historyGroupIndex, history)}

--- a/src/History/DragAndDrop.jsx
+++ b/src/History/DragAndDrop.jsx
@@ -1,33 +1,20 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 
 import { useUserId } from "../context/userIdContext";
 import { updateGroupsAndHistoriesAfterDragAndDrop } from "../firebase/afterDragAndDrop";
-import { getHistoryGroups } from "../firebase/getHistoryGroups";
 import { addEmptyGroup } from "../firebase/group";
+import useHistoryGroups from "../hooks/useHistoryGroups";
 import AddGroupButton from "../shared/AddGroupButton";
 import KeywordGroup from "./KeywordGroup";
 
 export default function DragAndDrop() {
   const dragPosition = useRef();
-  const [historyGroups, setHistoryGroups] = useState([]);
+  const [, setHistoryGroups] = useState([]);
   const { userId } = useUserId();
 
-  useEffect(() => {
-    let ignore = false;
-
-    async function initHistoryGroups() {
-      const groups = await getHistoryGroups(userId);
-      setHistoryGroups(groups);
-    }
-
-    if (!ignore && userId !== "") {
-      initHistoryGroups();
-    }
-
-    return () => {
-      ignore = true;
-    };
-  }, [userId]);
+  const {
+    historyGroupsQuery: { data: historyGroups },
+  } = useHistoryGroups();
 
   const startDrag = (historyGroupIndex, history) => {
     dragPosition.current = {
@@ -74,7 +61,6 @@ export default function DragAndDrop() {
       {historyGroups.map((historyGroup, historyGroupIndex) => (
         <KeywordGroup
           key={historyGroup.id}
-          addedGroupName={historyGroups}
           setAddedGroupName={setHistoryGroups}
           setHistoryGroups={setHistoryGroups}
           groupName={historyGroup.name}

--- a/src/History/DragAndDrop.jsx
+++ b/src/History/DragAndDrop.jsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from "react";
 
 import { useUserId } from "../context/userIdContext";
-import { addEmptyGroup } from "../firebase/group";
+import useGroups from "../hooks/useGroups";
 import useHistoryGroups from "../hooks/useHistoryGroups";
 import AddGroupButton from "../shared/AddGroupButton";
 import KeywordGroup from "./KeywordGroup";
@@ -15,6 +15,8 @@ export default function DragAndDrop() {
     historyGroupsQuery: { data: historyGroups },
     updateHistoryGroupsAfterDragAndDropMutation,
   } = useHistoryGroups();
+
+  const { addGroupMutation } = useGroups();
 
   const startDrag = (historyGroupIndex, history) => {
     dragPosition.current = {
@@ -45,15 +47,7 @@ export default function DragAndDrop() {
   }
 
   async function createHistoryGroup(groupName) {
-    const newGroupId = await addEmptyGroup(userId, groupName);
-
-    const newGroup = {
-      id: newGroupId,
-      name: groupName,
-      histories: [],
-    };
-
-    setHistoryGroups((prev) => [...prev, newGroup]);
+    addGroupMutation.mutate({ userId, groupName });
   }
 
   return (

--- a/src/History/DragAndDrop.jsx
+++ b/src/History/DragAndDrop.jsx
@@ -1,6 +1,5 @@
 import { useRef } from "react";
 
-import { useUserId } from "../context/userIdContext";
 import useGroups from "../hooks/useGroups";
 import useHistoryGroups from "../hooks/useHistoryGroups";
 import AddGroupButton from "../shared/AddGroupButton";
@@ -8,8 +7,6 @@ import KeywordGroup from "./KeywordGroup";
 
 export default function DragAndDrop() {
   const dragPosition = useRef();
-
-  const { userId } = useUserId();
 
   const {
     historyGroupsQuery: { data: historyGroups },
@@ -41,13 +38,12 @@ export default function DragAndDrop() {
     dragPosition.current = null;
 
     updateHistoryGroupsAfterDragAndDropMutation.mutate({
-      userId,
       newHistoryGroups,
     });
   }
 
   async function createHistoryGroup(groupName) {
-    addGroupMutation.mutate({ userId, groupName });
+    addGroupMutation.mutate({ groupName });
   }
 
   return (

--- a/src/History/DragAndDrop.jsx
+++ b/src/History/DragAndDrop.jsx
@@ -56,7 +56,6 @@ export default function DragAndDrop() {
       {historyGroups.map((historyGroup, historyGroupIndex) => (
         <KeywordGroup
           key={historyGroup.id}
-          setAddedGroupName={setHistoryGroups}
           setHistoryGroups={setHistoryGroups}
           groupName={historyGroup.name}
           historyGroup={historyGroup}

--- a/src/History/DragAndDrop.jsx
+++ b/src/History/DragAndDrop.jsx
@@ -1,7 +1,6 @@
 import { useRef, useState } from "react";
 
 import { useUserId } from "../context/userIdContext";
-import { updateGroupsAndHistoriesAfterDragAndDrop } from "../firebase/afterDragAndDrop";
 import { addEmptyGroup } from "../firebase/group";
 import useHistoryGroups from "../hooks/useHistoryGroups";
 import AddGroupButton from "../shared/AddGroupButton";
@@ -14,6 +13,7 @@ export default function DragAndDrop() {
 
   const {
     historyGroupsQuery: { data: historyGroups },
+    updateHistoryGroupsAfterDragAndDropMutation,
   } = useHistoryGroups();
 
   const startDrag = (historyGroupIndex, history) => {
@@ -38,9 +38,10 @@ export default function DragAndDrop() {
 
     dragPosition.current = null;
 
-    await updateGroupsAndHistoriesAfterDragAndDrop(userId, newHistoryGroups);
-
-    setHistoryGroups(newHistoryGroups);
+    updateHistoryGroupsAfterDragAndDropMutation.mutate({
+      userId,
+      newHistoryGroups,
+    });
   }
 
   async function createHistoryGroup(groupName) {

--- a/src/History/GroupDelte.jsx
+++ b/src/History/GroupDelte.jsx
@@ -1,3 +1,0 @@
-// export default function () {
-
-// }

--- a/src/History/HistoryItem.jsx
+++ b/src/History/HistoryItem.jsx
@@ -1,18 +1,16 @@
 import PropTypes from "prop-types";
 
 import { useUserId } from "../context/userIdContext";
-import { deleteHistory } from "../firebase/history";
+import useHistories from "../hooks/useHistories";
 import DeleteButton from "../shared/DeleteButton";
 import SearchUrl from "./SearchUrl";
 import { TotalKeywordButton } from "./TotalKeywordButton";
 
-export default function HistoryItem({
-  history,
-  onDragStart,
-  groupId,
-  setHistoryGroups,
-}) {
+export default function HistoryItem({ history, onDragStart, groupId }) {
   const { userId } = useUserId();
+
+  const { deleteHistoryMutation } = useHistories();
+
   return (
     <li
       className="flex flex-row justify-evenly w-[100%] items-center gap-[10px]"
@@ -35,23 +33,8 @@ export default function HistoryItem({
         <DeleteButton
           onClick={() => {
             const targetHistoryId = history.id;
-            deleteHistory(userId, groupId, targetHistoryId);
-            setHistoryGroups((prevGroups) => {
-              const updated = prevGroups.map((prevGroup) => {
-                if (prevGroup.id === groupId) {
-                  return {
-                    ...prevGroup,
-                    histories: prevGroup.histories.filter(
-                      (history) => history.id !== targetHistoryId
-                    ),
-                  };
-                } else {
-                  return prevGroup;
-                }
-              });
 
-              return updated;
-            });
+            deleteHistoryMutation.mutate({ userId, groupId, targetHistoryId });
           }}
         />
       </div>
@@ -63,5 +46,4 @@ HistoryItem.propTypes = {
   history: PropTypes.object.isRequired,
   onDragStart: PropTypes.func.isRequired,
   groupId: PropTypes.string.isRequired,
-  setHistoryGroups: PropTypes.func.isRequired,
 };

--- a/src/History/HistoryItem.jsx
+++ b/src/History/HistoryItem.jsx
@@ -1,14 +1,11 @@
 import PropTypes from "prop-types";
 
-import { useUserId } from "../context/userIdContext";
 import useHistories from "../hooks/useHistories";
 import DeleteButton from "../shared/DeleteButton";
 import SearchUrl from "./SearchUrl";
 import { TotalKeywordButton } from "./TotalKeywordButton";
 
 export default function HistoryItem({ history, onDragStart, groupId }) {
-  const { userId } = useUserId();
-
   const { deleteHistoryMutation } = useHistories();
 
   return (
@@ -34,7 +31,7 @@ export default function HistoryItem({ history, onDragStart, groupId }) {
           onClick={() => {
             const targetHistoryId = history.id;
 
-            deleteHistoryMutation.mutate({ userId, groupId, targetHistoryId });
+            deleteHistoryMutation.mutate({ groupId, targetHistoryId });
           }}
         />
       </div>

--- a/src/History/KeywordGroup.jsx
+++ b/src/History/KeywordGroup.jsx
@@ -6,7 +6,6 @@ import ChangeGroupName from "./ChangeGroupName";
 import HistoryItem from "./HistoryItem";
 
 export default function KeywordGroup({
-  addedGroupName,
   setAddedGroupName,
   groupName,
   historyGroup,
@@ -16,6 +15,7 @@ export default function KeywordGroup({
 }) {
   const { userId } = useUserId();
   const targetGroupId = historyGroup.id;
+
   return (
     <div className="newGroup h-full relative">
       <div>
@@ -26,7 +26,6 @@ export default function KeywordGroup({
         >
           <ChangeGroupName
             initialGroupName={groupName}
-            addedGroupName={addedGroupName}
             setAddedGroupName={setAddedGroupName}
           />
           <div className="gap-[10px]">
@@ -68,7 +67,6 @@ export default function KeywordGroup({
 }
 
 KeywordGroup.propTypes = {
-  addedGroupName: PropTypes.array.isRequired,
   setAddedGroupName: PropTypes.func.isRequired,
   groupName: PropTypes.string.isRequired,
   historyGroup: PropTypes.object.isRequired,

--- a/src/History/KeywordGroup.jsx
+++ b/src/History/KeywordGroup.jsx
@@ -1,6 +1,5 @@
 import PropTypes from "prop-types";
 
-import { useUserId } from "../context/userIdContext";
 import useHistoryGroups from "../hooks/useHistoryGroups";
 import ChangeGroupName from "./ChangeGroupName";
 import HistoryItem from "./HistoryItem";
@@ -11,7 +10,6 @@ export default function KeywordGroup({
   onDragStart,
   onDrop,
 }) {
-  const { userId } = useUserId();
   const targetGroupId = historyGroup.id;
 
   const { deleteHistoryGroupMutation } = useHistoryGroups();
@@ -47,7 +45,7 @@ export default function KeywordGroup({
               if (targetGroupId === "default") {
                 return;
               }
-              deleteHistoryGroupMutation.mutate({ userId, targetGroupId });
+              deleteHistoryGroupMutation.mutate({ targetGroupId });
             }}
             className=" w-DelBtnW h-DelBtnH rounded-sm hover:bg-[#ddd] absolute right-[10px] top-[10px] text-subPrimary1"
           >

--- a/src/History/KeywordGroup.jsx
+++ b/src/History/KeywordGroup.jsx
@@ -10,7 +10,6 @@ export default function KeywordGroup({
   historyGroup,
   onDragStart,
   onDrop,
-  setHistoryGroups,
 }) {
   const { userId } = useUserId();
   const targetGroupId = historyGroup.id;
@@ -36,7 +35,6 @@ export default function KeywordGroup({
                     onDragStart={onDragStart}
                     onDrop={onDrop}
                     groupId={historyGroup.id}
-                    setHistoryGroups={setHistoryGroups}
                   />
                 );
               })}
@@ -66,5 +64,4 @@ KeywordGroup.propTypes = {
   historyGroup: PropTypes.object.isRequired,
   onDragStart: PropTypes.func.isRequired,
   onDrop: PropTypes.func.isRequired,
-  setHistoryGroups: PropTypes.func.isRequired,
 };

--- a/src/History/KeywordGroup.jsx
+++ b/src/History/KeywordGroup.jsx
@@ -6,7 +6,6 @@ import ChangeGroupName from "./ChangeGroupName";
 import HistoryItem from "./HistoryItem";
 
 export default function KeywordGroup({
-  setAddedGroupName,
   groupName,
   historyGroup,
   onDragStart,
@@ -26,10 +25,7 @@ export default function KeywordGroup({
           onDrop={onDrop}
           onDragOver={(event) => event.preventDefault()}
         >
-          <ChangeGroupName
-            initialGroupName={groupName}
-            setAddedGroupName={setAddedGroupName}
-          />
+          <ChangeGroupName initialGroupName={groupName} />
           <div className="gap-[10px]">
             <ul className="pt-[30px]">
               {historyGroup.histories.map((history, historyIdex) => {
@@ -66,7 +62,6 @@ export default function KeywordGroup({
 }
 
 KeywordGroup.propTypes = {
-  setAddedGroupName: PropTypes.func.isRequired,
   groupName: PropTypes.string.isRequired,
   historyGroup: PropTypes.object.isRequired,
   onDragStart: PropTypes.func.isRequired,

--- a/src/History/KeywordGroup.jsx
+++ b/src/History/KeywordGroup.jsx
@@ -1,7 +1,7 @@
 import PropTypes from "prop-types";
 
 import { useUserId } from "../context/userIdContext";
-import { deleteGroup } from "../firebase/group";
+import useHistoryGroups from "../hooks/useHistoryGroups";
 import ChangeGroupName from "./ChangeGroupName";
 import HistoryItem from "./HistoryItem";
 
@@ -15,6 +15,8 @@ export default function KeywordGroup({
 }) {
   const { userId } = useUserId();
   const targetGroupId = historyGroup.id;
+
+  const { deleteHistoryGroupMutation } = useHistoryGroups();
 
   return (
     <div className="newGroup h-full relative">
@@ -51,10 +53,7 @@ export default function KeywordGroup({
               if (targetGroupId === "default") {
                 return;
               }
-              deleteGroup(userId, targetGroupId);
-              setHistoryGroups((prevGroups) =>
-                prevGroups.filter((preGroup) => preGroup.id !== targetGroupId)
-              );
+              deleteHistoryGroupMutation.mutate({ userId, targetGroupId });
             }}
             className=" w-DelBtnW h-DelBtnH rounded-sm hover:bg-[#ddd] absolute right-[10px] top-[10px] text-subPrimary1"
           >

--- a/src/hooks/useGroups.jsx
+++ b/src/hooks/useGroups.jsx
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { useUserId } from "../context/userIdContext";
+import { addEmptyGroup } from "../firebase/group";
+
+export default function useGroups() {
+  const { userId } = useUserId();
+  const queryClient = useQueryClient();
+
+  const addGroupMutation = useMutation({
+    mutationFn: async ({ userId, groupName }) => {
+      addEmptyGroup(userId, groupName);
+    },
+    onSuccess: async () => {
+      queryClient.invalidateQueries({ queryKey: ["historyGroups", userId] });
+    },
+  });
+
+  return {
+    addGroupMutation,
+  };
+}

--- a/src/hooks/useGroups.jsx
+++ b/src/hooks/useGroups.jsx
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { useUserId } from "../context/userIdContext";
-import { addEmptyGroup } from "../firebase/group";
+import { addEmptyGroup, updateGroupName } from "../firebase/group";
 
 export default function useGroups() {
   const { userId } = useUserId();
@@ -16,7 +16,17 @@ export default function useGroups() {
     },
   });
 
+  const updateGroupNameMutation = useMutation({
+    mutationFn: async ({ userId, groupId, groupName }) => {
+      await updateGroupName(userId, groupId, groupName);
+    },
+    onSuccess: async () => {
+      queryClient.invalidateQueries({ queryKey: ["historyGroups", userId] });
+    },
+  });
+
   return {
     addGroupMutation,
+    updateGroupNameMutation,
   };
 }

--- a/src/hooks/useGroups.jsx
+++ b/src/hooks/useGroups.jsx
@@ -8,7 +8,7 @@ export default function useGroups() {
   const queryClient = useQueryClient();
 
   const addGroupMutation = useMutation({
-    mutationFn: async ({ userId, groupName }) => {
+    mutationFn: async ({ groupName }) => {
       addEmptyGroup(userId, groupName);
     },
     onSuccess: async () => {
@@ -17,7 +17,7 @@ export default function useGroups() {
   });
 
   const updateGroupNameMutation = useMutation({
-    mutationFn: async ({ userId, groupId, groupName }) => {
+    mutationFn: async ({ groupId, groupName }) => {
       await updateGroupName(userId, groupId, groupName);
     },
     onSuccess: async () => {

--- a/src/hooks/useHistories.jsx
+++ b/src/hooks/useHistories.jsx
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { useUserId } from "../context/userIdContext";
+import { deleteHistory } from "../firebase/history";
+
+export default function useHistories() {
+  const queryClient = useQueryClient();
+  const { userId } = useUserId();
+
+  const deleteHistoryMutation = useMutation({
+    mutationFn: async ({ userId, groupId, targetHistoryId }) => {
+      await deleteHistory(userId, groupId, targetHistoryId);
+    },
+    onSuccess: async () => {
+      queryClient.invalidateQueries({ queryKey: ["historyGroups", userId] });
+    },
+  });
+
+  return {
+    deleteHistoryMutation,
+  };
+}

--- a/src/hooks/useHistories.jsx
+++ b/src/hooks/useHistories.jsx
@@ -8,7 +8,7 @@ export default function useHistories() {
   const { userId } = useUserId();
 
   const deleteHistoryMutation = useMutation({
-    mutationFn: async ({ userId, groupId, targetHistoryId }) => {
+    mutationFn: async ({ groupId, targetHistoryId }) => {
       await deleteHistory(userId, groupId, targetHistoryId);
     },
     onSuccess: async () => {

--- a/src/hooks/useHistoryGroups.jsx
+++ b/src/hooks/useHistoryGroups.jsx
@@ -1,0 +1,27 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { useUserId } from "../context/userIdContext";
+import { getHistoryGroups } from "../firebase/getHistoryGroups";
+
+export default function useHistoryGroups() {
+  const { userId } = useUserId();
+
+  const historyGroupsQuery = useQuery({
+    queryKey: ["historyGroups", userId],
+    queryFn: async () => {
+      if (!userId) {
+        return [];
+      }
+
+      const historyGroups = await getHistoryGroups(userId);
+      return historyGroups;
+    },
+    initialData: [],
+    staleTime: 1000 * 60,
+    refetchOnWindowFocus: false,
+  });
+
+  return {
+    historyGroupsQuery,
+  };
+}

--- a/src/hooks/useHistoryGroups.jsx
+++ b/src/hooks/useHistoryGroups.jsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useUserId } from "../context/userIdContext";
 import { updateGroupsAndHistoriesAfterDragAndDrop } from "../firebase/afterDragAndDrop";
 import { getHistoryGroups } from "../firebase/getHistoryGroups";
+import { deleteGroup } from "../firebase/group";
 
 export default function useHistoryGroups() {
   const { userId } = useUserId();
@@ -32,8 +33,18 @@ export default function useHistoryGroups() {
     },
   });
 
+  const deleteHistoryGroupMutation = useMutation({
+    mutationFn: async ({ userId, targetGroupId }) => {
+      await deleteGroup(userId, targetGroupId);
+    },
+    onSuccess: async () => {
+      queryClient.invalidateQueries({ queryKey: ["historyGroups", userId] });
+    },
+  });
+
   return {
     historyGroupsQuery,
     updateHistoryGroupsAfterDragAndDropMutation,
+    deleteHistoryGroupMutation,
   };
 }

--- a/src/hooks/useHistoryGroups.jsx
+++ b/src/hooks/useHistoryGroups.jsx
@@ -25,7 +25,7 @@ export default function useHistoryGroups() {
   });
 
   const updateHistoryGroupsAfterDragAndDropMutation = useMutation({
-    mutationFn: async ({ userId, newHistoryGroups }) => {
+    mutationFn: async ({ newHistoryGroups }) => {
       await updateGroupsAndHistoriesAfterDragAndDrop(userId, newHistoryGroups);
     },
     onSuccess: async () => {
@@ -34,7 +34,7 @@ export default function useHistoryGroups() {
   });
 
   const deleteHistoryGroupMutation = useMutation({
-    mutationFn: async ({ userId, targetGroupId }) => {
+    mutationFn: async ({ targetGroupId }) => {
       await deleteGroup(userId, targetGroupId);
     },
     onSuccess: async () => {

--- a/src/hooks/useHistoryGroups.jsx
+++ b/src/hooks/useHistoryGroups.jsx
@@ -1,10 +1,12 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { useUserId } from "../context/userIdContext";
+import { updateGroupsAndHistoriesAfterDragAndDrop } from "../firebase/afterDragAndDrop";
 import { getHistoryGroups } from "../firebase/getHistoryGroups";
 
 export default function useHistoryGroups() {
   const { userId } = useUserId();
+  const queryClient = useQueryClient();
 
   const historyGroupsQuery = useQuery({
     queryKey: ["historyGroups", userId],
@@ -21,7 +23,17 @@ export default function useHistoryGroups() {
     refetchOnWindowFocus: false,
   });
 
+  const updateHistoryGroupsAfterDragAndDropMutation = useMutation({
+    mutationFn: async ({ userId, newHistoryGroups }) => {
+      await updateGroupsAndHistoriesAfterDragAndDrop(userId, newHistoryGroups);
+    },
+    onSuccess: async () => {
+      queryClient.invalidateQueries({ queryKey: ["historyGroups", userId] });
+    },
+  });
+
   return {
     historyGroupsQuery,
+    updateHistoryGroupsAfterDragAndDropMutation,
   };
 }

--- a/src/hooks/useHistoryGroups.jsx
+++ b/src/hooks/useHistoryGroups.jsx
@@ -19,7 +19,7 @@ export default function useHistoryGroups() {
       const historyGroups = await getHistoryGroups(userId);
       return historyGroups;
     },
-    initialData: [],
+    placeholderData: [],
     staleTime: 1000 * 60,
     refetchOnWindowFocus: false,
   });


### PR DESCRIPTION
### 구현사진
![Jul-07-2025 13-55-31](https://github.com/user-attachments/assets/78dfdcef-bbe6-493e-bb94-9d3dd2c54bca)

### 작업 내용
- tanstack query를 사용하여 캐시기능 사용, 프롭드릴링 완화, 중복 코드 정리, 즉각적인 서버 상태가 반영됩니다.
- 커스텀 훅으로 서버 상태(firestore)를 관리하는 로직을 분리해 분배했습니다.
- useGroups: 
  - 빈 group 생성
  - group 이름 업데이트
- useHistories: 
  - history 삭제
- useHistoryGroups: 
  - history까지 모두 채워진 group들 읽기(historyGroups)
  - DragAndDrop이후, 원래 group의 history를 삭제 후, 이동된 group에 history 삽입
  - group 삭제(내부 history들도 함께 삭제)

### 기존 계획과 달라진 부분(+이유와 함께)
- tanstack query를 잘 활용하기 위해, 권장사항으로 함께 제공되는 개발자도구를 사용했습니다.
- 위의 개발자도구는 개발환경에서만 적용되며, 프로덕션환경에는 포함되지 않습니다.

### 구현한 내용(체크박스로 나타내기)
- [x] DragAndDrop 컴포넌트의 historyGroups 상태를 대상으로 합니다.
- [x] 빈 group 생성
- [x] group 이름 업데이트
- [x] history 삭제
- [x] history까지 모두 채워진 group들 읽기(historyGroups)
- [x] DragAndDrop이후, 원래 group의 history를 삭제 후, 이동된 group에 history 삽입
- [x] group 삭제

### 리뷰어가 집중적으로 바줬으면 하는 것
- 위에서 아래로 읽었을 경우 가독성
- pull 받아서 테스트시 기능적인 보완 부분 유무

### 관련 이슈
Closes #40 
